### PR TITLE
Added Jenkins message to slack on Master Build Failures

### DIFF
--- a/cxs/ci/Jenkinsfile
+++ b/cxs/ci/Jenkinsfile
@@ -19,7 +19,9 @@ node('ubuntu') {
         buildRust(app)
         testRust(app) 
         testNodeWrapper(app)
-        createZip(app)
+        if (env.BRANCH_NAME == "master") {
+            createZip(app)
+        }
     } catch (Exception ex) {
         currentBuild.result = "FAILED"
         if (env.BRANCH_NAME == "master") {


### PR DESCRIPTION
On Master Build failures a slack message will be generated to the #jenkins channel.