### PR TITLE
Fixed Proof deserialize test

### DIFF
--- a/cxs/libcxs/src/api/proof.rs
+++ b/cxs/libcxs/src/api/proof.rs
@@ -96,10 +96,7 @@ pub extern fn cxs_proof_deserialize(command_handle: u32,
             Ok(x) => (error::SUCCESS.code_num, x),
             Err(x) => (x, 0),
         };
-<<<<<<< HEAD
 
-=======
->>>>>>> rustlib_singleton
         cb(command_handle, rc, handle);
     });
 


### PR DESCRIPTION
This test was missing a Proof struct member inside of a json string. 