### PR TITLE
enable "indy" and "agency" test mode (or both)

### DIFF
--- a/cxs/libcxs/src/api/cxs.rs
+++ b/cxs/libcxs/src/api/cxs.rs
@@ -120,9 +120,9 @@ pub extern fn cxs_init (command_handle: u32,
 
     thread::spawn(move|| {
         /* TODO: handle pool config */
-        pool::create_pool_ledger_config(&pool_name,Some(&config_name));
-        let wrc = match wallet::init_wallet(&wallet_name, &pool_name, &wallet_type) {
-            Ok(x) => error::SUCCESS.code_num,
+        pool::create_pool_ledger_config();
+        let wrc = match wallet::init_wallet(&wallet_name) {
+            Ok(_) => error::SUCCESS.code_num,
             Err(x) => x,
         };
 
@@ -182,7 +182,6 @@ mod tests {
 
     #[test]
     fn test_init_with_file() {
-        wallet::tests::delete_wallet("dummy");
         settings::set_defaults();
         settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE,"true");
         let config_path = "/tmp/test_init.json";
@@ -207,6 +206,7 @@ mod tests {
         thread::sleep(Duration::from_secs(1));
         // Leave file around or other concurrent tests will fail
         //fs::remove_file(config_path).unwrap();
+        wallet::delete_wallet("my_wallet").unwrap();
     }
 
 
@@ -223,5 +223,6 @@ mod tests {
         let result = cxs_init(0,ptr::null(),Some(init_cb));
         assert_eq!(result,0);
         thread::sleep(Duration::from_secs(1));
+        wallet::delete_wallet("wallet1").unwrap();
     }
 }

--- a/cxs/libcxs/src/api/issuer_claim.rs
+++ b/cxs/libcxs/src/api/issuer_claim.rs
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn test_cxs_issuer_send_claim_offer() {
         settings::set_defaults();
-        settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE,"false");
+        settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE,"indy");
         settings::set_config_value(settings::CONFIG_AGENT_ENDPOINT, mockito::SERVER_URL);
         let _m = mockito::mock("POST", "/agency/route")
             .with_status(200)
@@ -305,8 +305,8 @@ mod tests {
     #[test]
     fn test_cxs_issuer_send_a_claim() {
         settings::set_defaults();
-        wallet::tests::make_wallet("test_cxs_issuer_send_a_claim");
-        settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE,"false");
+        wallet::init_wallet("test_cxs_issuer_send_a_claim").unwrap();
+        settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE,"indy");
         settings::set_config_value(settings::CONFIG_AGENT_ENDPOINT, mockito::SERVER_URL);
         settings::set_config_value(settings::CONFIG_ENTERPRISE_DID, DEFAULT_DID);
         use claim_request::ClaimRequest;
@@ -332,7 +332,7 @@ mod tests {
         issuer_claim::set_claim_request(handle, &claim_request).unwrap();
         assert_eq!(issuer_claim::get_state(handle),CxsStateType::CxsStateRequestReceived as u32);
         let schema = create_default_schema(schema_seq_num);
-        wallet::tests::make_wallet("test_cxs_issuer_send_a_claim");
+        assert!(wallet::init_wallet("test_cxs_issuer_send_a_claim").unwrap() > 0);
         put_claim_def_in_issuer_wallet(&settings::get_config_value(
             settings::CONFIG_ENTERPRISE_DID).unwrap(), &schema, get_wallet_handle());
         /**********************************************************************/
@@ -352,7 +352,7 @@ mod tests {
         assert_eq!(cxs_issuer_send_claim(command_handle, handle, connection_handle, Some(send_offer_cb)), error::SUCCESS.code_num);
         thread::sleep(Duration::from_millis(1000));
         _m.assert();
-        wallet::tests::delete_wallet("test_cxs_issuer_send_a_claim");
+        wallet::delete_wallet("test_cxs_issuer_send_a_claim").unwrap();
     }
     extern "C" fn deserialize_cb(command_handle: u32, err: u32, claim_handle: u32) {
         fn formatter(original: &str) -> String {

--- a/cxs/libcxs/src/messages/message.rs
+++ b/cxs/libcxs/src/messages/message.rs
@@ -7,7 +7,6 @@ use settings;
 use utils::httpclient;
 use utils::error;
 use messages::GeneralMessage;
-use self::rmp_serde::encode;
 
 #[derive(Clone, Serialize, Debug, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
@@ -112,19 +111,11 @@ impl GeneralMessage for GetMessages{
 
     fn set_to_vk(&mut self, to_vk: String){ self.to_vk = to_vk; }
 
-    fn to_post(&mut self) -> Result<Vec<u8>,u32> {
+    fn to_post(&self) -> Result<Vec<u8>,u32> {
         if self.validate_rc != error::SUCCESS.code_num {
             return Err(self.validate_rc)
         }
-        self.agent_payload = json!(self.payload).to_string();
-
-        match encode::to_vec_named(self) {
-            Ok(x) => Ok(x),
-            Err(x) => {
-                error!("could not serialize payload: {}", x);
-                return Err(error::INVALID_MSGPACK.code_num);
-            },
-        }
+        Ok(Vec::new().to_owned())
     }
 
     fn send_enc(&mut self) -> Result<String, u32> {
@@ -256,19 +247,12 @@ impl GeneralMessage for SendMessage{
 
     fn set_to_vk(&mut self, to_vk: String){ self.to_vk = to_vk; }
 
-    fn to_post(&mut self) -> Result<Vec<u8>, u32> {
+    fn to_post(&self) -> Result<Vec<u8>, u32> {
         if self.validate_rc != error::SUCCESS.code_num {
             return Err(self.validate_rc)
         }
-        self.agent_payload = json!(self.payload).to_string();
 
-        match encode::to_vec_named(self) {
-            Ok(x) => Ok(x),
-            Err(x) => {
-                error!("could not serialize payload: {}", x);
-                return Err(error::INVALID_MSGPACK.code_num);
-            },
-        }
+        Ok(Vec::new().to_owned())
     }
 
     fn send_enc(&mut self) -> Result<String, u32> {

--- a/cxs/libcxs/src/messages/mod.rs
+++ b/cxs/libcxs/src/messages/mod.rs
@@ -24,6 +24,12 @@ pub enum MessageType {
     GetMessagesMsg(GetMessages),
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct MsgResponse {
+    msg_type: String,
+    msg_id: String,
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, PartialOrd)]
 pub struct Bundled<T> {
     bundled: Vec<T>,
@@ -63,6 +69,12 @@ pub fn bundle_for_agency(message: Vec<u8>, did: &str) -> Result<Vec<u8>, u32> {
     crypto::prep_anonymous_msg(&agency_vk, &msg[..])
 }
 
+pub fn unbundle_from_agency(message: Vec<u8>) -> Result<Vec<u8>, u32> {
+    let my_vk = settings::get_config_value(settings::CONFIG_ENTERPRISE_VERKEY).unwrap();
+
+    crypto::parse_msg(wallet::get_wallet_handle(), &my_vk, &message[..])
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, PartialOrd)]
 struct Forward {
     #[serde(rename = "@type")]
@@ -98,7 +110,7 @@ pub trait GeneralMessage{
     fn set_to_did(&mut self, to_did: String);
     fn set_validate_rc(&mut self, rc: u32);
     fn send(&mut self) -> Result<String, u32>;
-    fn to_post(&mut self) -> Result<Vec<u8>, u32>;
+    fn to_post(&self) -> Result<Vec<u8>, u32>;
     fn send_enc(&mut self) -> Result<String, u32>;
 
 }

--- a/cxs/libcxs/src/proof.rs
+++ b/cxs/libcxs/src/proof.rs
@@ -130,7 +130,7 @@ pub fn from_string(proof_data: &str) -> Result<u32, u32> {
 }
 
 fn get_offer_details(response: &str) -> Result<String, u32> {
-    if settings::test_mode_enabled() {return Ok("test_mode_response".to_owned());}
+    if settings::test_agency_mode_enabled() {return Ok("test_mode_response".to_owned());}
     match serde_json::from_str(response) {
         Ok(json) => {
             let json: serde_json::Value = json;

--- a/cxs/libcxs/src/settings.rs
+++ b/cxs/libcxs/src/settings.rs
@@ -121,12 +121,21 @@ fn validate_config() -> Result<u32, String> {
     }
 }
 
-pub fn test_mode_enabled() -> bool {
+pub fn test_indy_mode_enabled() -> bool {
+     let config = SETTINGS.read().unwrap();
+
+    match config.get_str(CONFIG_ENABLE_TEST_MODE) {
+        Err(_) => false,
+        Ok(value) => if value == "true" { true } else { if value == "indy" { true } else {false }},
+    }
+}
+
+pub fn test_agency_mode_enabled() -> bool {
     let config = SETTINGS.read().unwrap();
 
     match config.get_str(CONFIG_ENABLE_TEST_MODE) {
         Err(_) => false,
-        Ok(value) => if value == "true" { true } else { false },
+        Ok(value) => if value == "true" { true } else { if value == "agency" { true } else {false }},
     }
 }
 

--- a/cxs/libcxs/src/utils/httpclient.rs
+++ b/cxs/libcxs/src/utils/httpclient.rs
@@ -1,11 +1,13 @@
 use settings;
 use std::io::Read;
 use reqwest;
+use reqwest::header::{ContentType};
+
 
 pub fn post(body_content: &str, url: &str) -> Result<String,String> {
     let client = reqwest::Client::new();
     info!("Posting \"{}\" to: \"{}\"", body_content, url);
-    if settings::test_mode_enabled() {return Ok("test_mode_response".to_owned());}
+    if settings::test_agency_mode_enabled() {return Ok("test_mode_response".to_owned());}
     let mut response = match  client.post(url).body(body_content.to_owned()).send() {
         Ok(result) => result,
         Err(err) => return Err("could not connect".to_string()),
@@ -25,8 +27,8 @@ pub fn post(body_content: &str, url: &str) -> Result<String,String> {
 pub fn post_u8(body_content: &Vec<u8>, url: &str) -> Result<Vec<u8>,String> {
     let client = reqwest::Client::new();
     info!("Posting \"{:?}\" to: \"{}\"", body_content, url);
-    if settings::test_mode_enabled() {return Ok(Vec::new().to_owned());}
-    let mut response = match  client.post(url).body(body_content.to_owned()).send() {
+    if settings::test_agency_mode_enabled() {return Ok(Vec::new().to_owned());}
+    let mut response = match  client.post(url).body(body_content.to_owned()).header(ContentType::octet_stream()).send() {
         Ok(result) => result,
         Err(err) => return Err("could not connect".to_string()),
     };

--- a/cxs/libcxs/src/utils/signus.rs
+++ b/cxs/libcxs/src/utils/signus.rs
@@ -24,7 +24,7 @@ pub struct SignusUtils {}
 impl SignusUtils {
 
     pub fn create_and_store_my_did(wallet_handle: i32, seed: Option<&str>) -> Result<(String, String), i32> {
-        if settings::test_mode_enabled() {
+        if settings::test_indy_mode_enabled() {
             return Ok(("8XFh8yBzrpJQmNyZzgoTqB".to_owned(), "EkVTa7SCJ5SntpYyX7CSb2pcBhiVGT9kWSagA8a9T69A".to_owned()));
         }
 
@@ -57,7 +57,7 @@ impl SignusUtils {
     }
 
     pub fn store_their_did_from_parts(wallet_handle: i32, their_did: &str, their_verkey: &str) -> Result<(), i32> {
-        if settings::test_mode_enabled() { return Ok(()) }
+        if settings::test_indy_mode_enabled() { return Ok(()) }
 
         let (store_their_did_sender, store_their_did_receiver) = channel();
         let store_their_did_cb = Box::new(move |err| { store_their_did_sender.send((err)).unwrap(); });

--- a/cxs/libcxs/src/utils/wallet.rs
+++ b/cxs/libcxs/src/utils/wallet.rs
@@ -51,11 +51,20 @@ extern {
 
 pub fn get_wallet_handle() -> i32 { unsafe { WALLET_HANDLE } }
 
-pub fn init_wallet(wallet_name: &str, pool_name: &str, wallet_type: &str) -> Result<i32, u32> {
-    if settings::test_mode_enabled() {
+pub fn init_wallet(wallet_name: &str) -> Result<i32, u32> {
+    if settings::test_indy_mode_enabled() {
         unsafe {WALLET_HANDLE = 1;}
         return Ok(1);
     }
+    let pool_name = match settings::get_config_value(settings::CONFIG_POOL_NAME) {
+        Ok(x) => x,
+        Err(_) => "pool1".to_owned(),
+    };
+
+    let wallet_type = match settings::get_config_value(settings::CONFIG_WALLET_TYPE) {
+        Ok(x) => x,
+        Err(_) => "default".to_owned(),
+    };
 
     let (sender, receiver) = channel();
     let (open_sender, open_receiver) = channel();
@@ -118,6 +127,11 @@ pub fn init_wallet(wallet_name: &str, pool_name: &str, wallet_type: &str) -> Res
 }
 
 pub fn delete_wallet(wallet_name: &str) -> Result<(), i32> {
+    if settings::test_indy_mode_enabled() {
+        unsafe { WALLET_HANDLE = 0;}
+        return Ok(())
+    }
+
     let (sender, receiver) = channel();
 
     let cb = Box::new(move |err| {
@@ -221,57 +235,23 @@ pub mod tests {
     use super::*;
     use utils::error;
     use std::thread;
-    use utils::generate_command_handle;
     use std::time::Duration;
-    use utils::cstring::CStringUtils;
-
-    //TODO: make boilerplate test code use same wallet?
-
-    pub fn make_wallet(wallet_name: &str) {
-        let pool_name = String::from("pool1");
-        let wallet_type = String::from("default");
-        assert!(init_wallet(&wallet_name, &pool_name, &wallet_type).unwrap() >  0);
-    }
-
-    pub fn delete_wallet(wallet_name: &str) {
-        let handle = generate_command_handle();
-        extern "C" fn dummy_callback(_handle: i32, _err: i32) { }
-
-        let wallet_handle = get_wallet_handle();
-
-        unsafe {
-            let indy_err = indy_close_wallet(handle,
-                                             wallet_handle,
-                                             Some(dummy_callback));
-        }
-
-        unsafe {
-           let indy_err = indy_delete_wallet(handle,
-                                             CStringUtils::string_to_cstring(wallet_name.to_string()).as_ptr(),
-                                             null(),
-                                             Some(dummy_callback));
-        }
-        thread::sleep(Duration::from_secs(1));
-        unsafe { WALLET_HANDLE = 0; }
-    }
 
     #[test]
     fn test_wallet() {
         settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE,"false");
-        let pool_name = String::from("pool1");
         let wallet_name = String::from("wallet1");
-        let wallet_type = String::from("default");
-        assert!(init_wallet(&wallet_name, &pool_name, &wallet_type).unwrap() > 0);
-        assert_eq!(error::UNKNOWN_ERROR.code_num, init_wallet(&String::from(""),&pool_name, &wallet_type).unwrap_err());
+        assert!(init_wallet(&wallet_name).unwrap() > 0);
+        assert_eq!(error::UNKNOWN_ERROR.code_num, init_wallet(&String::from("")).unwrap_err());
 
         thread::sleep(Duration::from_secs(1));
-        delete_wallet("wallet1");
+        delete_wallet("wallet1").unwrap();
         let handle = get_wallet_handle();
         let wallet_name2 = String::from("wallet2");
-        assert!(init_wallet(&wallet_name2, &pool_name, &wallet_type).unwrap() > 0);
+        assert!(init_wallet(&wallet_name2).unwrap() > 0);
 
         thread::sleep(Duration::from_secs(1));
         assert_ne!(handle, get_wallet_handle());
-        delete_wallet("wallet2");
+        delete_wallet("wallet2").unwrap();
     }
 }

--- a/cxs/libcxs/tests/end_to_end.rs
+++ b/cxs/libcxs/tests/end_to_end.rs
@@ -121,20 +121,26 @@ extern "C" fn create_and_send_offer_cb(command_handle: u32, err: u32, claim_hand
 
 #[test]
 fn claim_offer_ete() {
-    let their_wallet = wallet::init_wallet("claim_offer_ete_mine", "pool_1", "Default").unwrap();
-    let my_wallet = wallet::init_wallet("claim_offer_ete_theirs", "pool_1", "Default").unwrap();
+    let agency_wallet = wallet::init_wallet("claim_offer_ete_agency").unwrap();
+    let agent_wallet = wallet::init_wallet("claim_offer_ete_agent").unwrap();
+    let my_wallet = wallet::init_wallet("claim_offer_ete_mine").unwrap();
 
-    let (their_did, their_vk) = SignusUtils::create_and_store_my_did(their_wallet, Some("00000000000000000000000000000My1")).unwrap();
-    let (my_did, my_vk) = SignusUtils::create_and_store_my_did(my_wallet, Some("00000000000000000000000000000My2")).unwrap();
+    let (my_did, my_vk) = SignusUtils::create_and_store_my_did(my_wallet, Some("00000000000000000000000000000My1")).unwrap();
+    let (agent_did, agent_vk) = SignusUtils::create_and_store_my_did(agent_wallet, Some("00000000000000000000000000000My2")).unwrap();
+    let (agency_did, agency_vk) = SignusUtils::create_and_store_my_did(agency_wallet, Some("00000000000000000000000000000My3")).unwrap();
 
-    SignusUtils::store_their_did_from_parts(my_wallet, their_did.as_ref(), their_vk.as_ref()).unwrap();
-    SignusUtils::store_their_did_from_parts(their_wallet, my_did.as_ref(), my_vk.as_ref()).unwrap();
+    SignusUtils::store_their_did_from_parts(my_wallet, agent_did.as_ref(), agent_vk.as_ref()).unwrap();
+    SignusUtils::store_their_did_from_parts(my_wallet, agency_did.as_ref(), agency_vk.as_ref()).unwrap();
 
-    wallet::close_wallet(their_wallet).unwrap();
+    wallet::close_wallet(agent_wallet).unwrap();
+    wallet::close_wallet(agency_wallet).unwrap();
     wallet::close_wallet(my_wallet).unwrap();
+    println!("mydid:  {} vk: {}", my_did, my_vk);
+    println!("agent:  {} vk: {}", agent_did, agent_vk);
+    println!("agency: {} vk: {}", agency_did, agency_vk);
 
     let config_string = format!("{{\"agent_endpoint\":\"{}\",\
-    \"agency_pairwise_did\":\"72x8p4HubxzUK1dwxcc5FU\",\
+    \"agency_pairwise_did\":\"{}\",\
     \"agent_pairwise_did\":\"{}\",\
     \"enterprise_did_agency\":\"RF3JM851T4EQmhh8CdagSP\",\
     \"enterprise_did_agent\":\"{}\",\
@@ -142,8 +148,8 @@ fn claim_offer_ete() {
     \"agent_enterprise_verkey\":\"{}\",\
     \"wallet_name\":\"claim_offer_ete_mine\",\
     \"logo_url\":\"https://s19.postimg.org/ykyz4x8jn/evernym.png\",\
-    \"agency_pairwise_verkey\":\"7118p4HubxzUK1dwxcc5FU\",\
-    \"agent_pairwise_verkey\":\"{}\"}}", mockito::SERVER_URL, their_did, my_did, their_vk, my_vk);
+    \"agency_pairwise_verkey\":\"{}\",\
+    \"agent_pairwise_verkey\":\"{}\"}}", mockito::SERVER_URL, agency_did, agent_did, my_did, my_vk, agency_vk, agent_vk);
 
     let mut file = NamedTempFileOptions::new()
         .suffix(".json")
@@ -172,7 +178,8 @@ fn claim_offer_ete() {
     thread::sleep(Duration::from_secs(4));
     unsafe {assert_eq!(CLAIM_SENT,true);}
     wallet::delete_wallet("claim_offer_ete_mine").unwrap();
-    wallet::delete_wallet("claim_offer_ete_theirs").unwrap();
+    wallet::delete_wallet("claim_offer_ete_agent").unwrap();
+    wallet::delete_wallet("claim_offer_ete_agency").unwrap();
 }
 
 #[test]


### PR DESCRIPTION
refactor tests with new indy test mode
enable parsing of encrypted responses from agency (not turned on)