### PR TITLE
Updated error handling in node wrapper

### DIFF
--- a/vcx/wrappers/node/src/api/claimDef.ts
+++ b/vcx/wrappers/node/src/api/claimDef.ts
@@ -79,7 +79,7 @@ export class ClaimDef extends VCXBase {
       ))
       return claimDef
     } catch (err) {
-      throw new VCXInternalError(`vcx_claimdef_create -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_claimdef_create')
     }
   }
 
@@ -104,7 +104,7 @@ export class ClaimDef extends VCXBase {
       }
       return await super._deserialize(ClaimDef, data, claimDefParams)
     } catch (err) {
-      throw new VCXInternalError(`vcx_claimdef_deserialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_claimdef_deserialize')
     }
   }
 
@@ -122,7 +122,7 @@ export class ClaimDef extends VCXBase {
       const data: IClaimDefObj = JSON.parse(await super._serialize())
       return data
     } catch (err) {
-      throw new VCXInternalError(`vcx_claimdef_serialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_claimdef_serialize')
     }
   }
 }

--- a/vcx/wrappers/node/src/api/connection.ts
+++ b/vcx/wrappers/node/src/api/connection.ts
@@ -61,7 +61,7 @@ export class Connection extends VCXBaseWithState {
       await connection._create((cb) => rustAPI().vcx_connection_create(commandHandle, recipientInfo.id, cb))
       return connection
     } catch (err) {
-      throw new VCXInternalError(`vcx_connection_create -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_connection_create')
     }
   }
 
@@ -83,7 +83,7 @@ export class Connection extends VCXBaseWithState {
       const connection = await super._deserialize(Connection, connectionData)
       return connection
     } catch (err) {
-      throw new VCXInternalError(`vcx_connection_deserialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_connection_deserialize')
     }
   }
 
@@ -119,8 +119,8 @@ export class Connection extends VCXBaseWithState {
             resolve(details)
           })
         )
-    } catch (error) {
-      throw new VCXInternalError(`vcx_connection_connect -> ${error}`)
+    } catch (err) {
+      throw new VCXInternalError(err, 'vcx_connection_connect')
     }
   }
 
@@ -138,7 +138,7 @@ export class Connection extends VCXBaseWithState {
       const data: IConnectionData = JSON.parse(await super._serialize())
       return data
     } catch (err) {
-      throw new VCXInternalError(`vcx_connection_serialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_connection_serialize')
     }
   }
 
@@ -152,8 +152,8 @@ export class Connection extends VCXBaseWithState {
   async updateState (): Promise<void> {
     try {
       await this._updateState()
-    } catch (error) {
-      throw new VCXInternalError(`vcx_connection_updateState -> ${error}`)
+    } catch (err) {
+      throw new VCXInternalError(err, 'vcx_connection_updateState')
     }
   }
 
@@ -167,8 +167,8 @@ export class Connection extends VCXBaseWithState {
   async getState (): Promise<number> {
     try {
       return await this._getState()
-    } catch (error) {
-      throw new VCXInternalError(`vcx_connection_get_state -> ${error}`)
+    } catch (err) {
+      throw new VCXInternalError(err, 'vcx_connection_get_state')
     }
   }
 
@@ -185,7 +185,7 @@ export class Connection extends VCXBaseWithState {
       const data: string = await this._inviteDetails(abbr)
       return data
     } catch (err) {
-      throw new VCXInternalError(`vcx_connection_invite_details -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_connection_invite_details')
     }
   }
 

--- a/vcx/wrappers/node/src/api/errors.ts
+++ b/vcx/wrappers/node/src/api/errors.ts
@@ -1,4 +1,0 @@
-// tslint:disable max-classes-per-file
-export class ConnectionTimeoutError extends Error {}
-
-export class VCXInternalError extends Error {}

--- a/vcx/wrappers/node/src/api/init.ts
+++ b/vcx/wrappers/node/src/api/init.ts
@@ -30,6 +30,6 @@ export async function initVcx (configPath: string, options: IInitVCXOptions = {}
       })
     )
   } catch (err) {
-    throw new VCXInternalError(`vcx_init -> ${err}`)
+    throw new VCXInternalError(err, 'vcx_init')
   }
 }

--- a/vcx/wrappers/node/src/api/issuerClaim.ts
+++ b/vcx/wrappers/node/src/api/issuerClaim.ts
@@ -100,7 +100,7 @@ export class IssuerClaim extends VCXBaseWithState {
       )
       return claim
     } catch (err) {
-      throw new VCXInternalError(`vcx_issuer_create_claim -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_issuer_create_claim')
     }
   }
 
@@ -128,7 +128,7 @@ export class IssuerClaim extends VCXBaseWithState {
       const claim = await super._deserialize<IssuerClaim, IClaimParams>(IssuerClaim, claimData, params)
       return claim
     } catch (err) {
-      throw new VCXInternalError(`vcx_issuer_claim_deserialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_issuer_claim_deserialize')
     }
   }
 
@@ -142,8 +142,8 @@ export class IssuerClaim extends VCXBaseWithState {
   async getState (): Promise<number> {
     try {
       return await this._getState()
-    } catch (error) {
-      throw new VCXInternalError(`vcx_issuer_claim_get_state -> ${error}`)
+    } catch (err) {
+      throw new VCXInternalError(err, 'vcx_issuer_claim_get_state')
     }
   }
 
@@ -157,8 +157,8 @@ export class IssuerClaim extends VCXBaseWithState {
   async updateState (): Promise<void> {
     try {
       await this._updateState()
-    } catch (error) {
-      throw new VCXInternalError(`vcx_issuer_claim_updateState -> ${error}`)
+    } catch (err) {
+      throw new VCXInternalError(err, 'vcx_issuer_claim_updateState')
     }
   }
 
@@ -175,7 +175,7 @@ export class IssuerClaim extends VCXBaseWithState {
     try {
       return JSON.parse(await super._serialize())
     } catch (err) {
-      throw new VCXInternalError(`vcx_issuer_claim_serialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_issuer_claim_serialize')
     }
   }
 
@@ -208,7 +208,7 @@ export class IssuerClaim extends VCXBaseWithState {
         )
     } catch (err) {
       // TODO handle error
-      throw new VCXInternalError(`vcx_issuer_send_claim_offer -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_issuer_send_claim_offer')
     }
   }
 
@@ -240,7 +240,7 @@ export class IssuerClaim extends VCXBaseWithState {
         })
       )
     } catch (err) {
-      throw new VCXInternalError(`vcx_issuer_send_claim -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_issuer_send_claim')
     }
   }
 

--- a/vcx/wrappers/node/src/api/proof.ts
+++ b/vcx/wrappers/node/src/api/proof.ts
@@ -110,7 +110,7 @@ export class Proof extends VCXBaseWithState {
       ))
       return proof
     } catch (err) {
-      throw new VCXInternalError(`vcx_proof_create -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_proof_create')
     }
   }
 
@@ -132,7 +132,7 @@ export class Proof extends VCXBaseWithState {
       const proof = await super._deserialize(Proof, proofData)
       return proof
     } catch (err) {
-      throw new VCXInternalError(`vcx_proof_deserialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_proof_deserialize')
     }
   }
 
@@ -150,7 +150,7 @@ export class Proof extends VCXBaseWithState {
       const data: IProofData = JSON.parse(await super._serialize())
       return data
     } catch (err) {
-      throw new VCXInternalError(`vcx_proof_serialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_proof_serialize')
     }
   }
 
@@ -164,8 +164,8 @@ export class Proof extends VCXBaseWithState {
   async getState (): Promise<number> {
     try {
       return await this._getState()
-    } catch (error) {
-      throw new VCXInternalError(`vcx_proof_get_state -> ${error}`)
+    } catch (err) {
+      throw new VCXInternalError(err, 'vcx_proof_get_state')
     }
   }
 
@@ -179,8 +179,8 @@ export class Proof extends VCXBaseWithState {
   async updateState (): Promise<void> {
     try {
       await this._updateState()
-    } catch (error) {
-      throw new VCXInternalError(`vcx_proof_updateState -> ${error}`)
+    } catch (err) {
+      throw new VCXInternalError(err, 'vcx_proof_updateState')
     }
   }
 
@@ -212,7 +212,7 @@ export class Proof extends VCXBaseWithState {
           })
         )
     } catch (err) {
-      throw new VCXInternalError(`vcx_proof_send_request -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_proof_send_request')
     }
   }
 
@@ -237,7 +237,7 @@ export class Proof extends VCXBaseWithState {
         )
       return {proofAttrs: JSON.parse(proof), proofState: this.getProofState()}
     } catch (err) {
-      throw new VCXInternalError(`vcx_get_proof -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_get_proof')
     }
   }
 

--- a/vcx/wrappers/node/src/api/schema.ts
+++ b/vcx/wrappers/node/src/api/schema.ts
@@ -91,7 +91,7 @@ export class Schema extends VCXBase {
       await schema.getSchemaNo()
       return schema
     } catch (err) {
-      throw new VCXInternalError(`vcx_schema_create -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_schema_create')
     }
   }
 
@@ -117,7 +117,7 @@ export class Schema extends VCXBase {
       }
       return await super._deserialize(Schema, schema, schemaParams)
     } catch (err) {
-      throw new VCXInternalError(`vcx_schema_deserialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_schema_deserialize')
     }
   }
 
@@ -160,7 +160,7 @@ export class Schema extends VCXBase {
       newSchema._handle = JSON.stringify(schemaObj.handle)
       return newSchema
     } catch (err) {
-      throw new VCXInternalError(`vcx_schema_get_attributes -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_schema_get_attributes')
     }
   }
 
@@ -178,7 +178,7 @@ export class Schema extends VCXBase {
       const data: ISchemaObj = JSON.parse(await super._serialize())
       return data
     } catch (err) {
-      throw new VCXInternalError(`vcx_schema_serialize -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_schema_serialize')
     }
   }
 
@@ -203,7 +203,7 @@ export class Schema extends VCXBase {
         )
       return schemaNo
     } catch (err) {
-      throw new VCXInternalError(`vcx_schema_get_sequence_no -> ${err}`)
+      throw new VCXInternalError(err, 'vcx_proof_create')
     }
   }
 

--- a/vcx/wrappers/node/src/errors.ts
+++ b/vcx/wrappers/node/src/errors.ts
@@ -1,4 +1,20 @@
 // tslint:disable max-classes-per-file
 export class ConnectionTimeoutError extends Error {}
 
-export class VCXInternalError extends Error {}
+export class VCXInternalError {
+  private _message: string
+  private _code: number
+
+  constructor (code: number, message: string) {
+    this._message = message
+    this._code = code
+  }
+
+  get message () {
+    return this._message
+  }
+
+  get code () {
+    return this._code
+  }
+}

--- a/vcx/wrappers/node/test/claimDefTest.js
+++ b/vcx/wrappers/node/test/claimDefTest.js
@@ -49,7 +49,8 @@ describe('A ClaimDef', function () {
     try {
       await claimDef.serialize()
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_claimdef_serialize -> 1037')
+      assert.equal(error.code, 1037)
+      assert.equal(error.message, 'vcx_claimdef_serialize')
     }
   })
 })

--- a/vcx/wrappers/node/test/connectionTest.js
+++ b/vcx/wrappers/node/test/connectionTest.js
@@ -61,7 +61,8 @@ describe('A Connection object with ', function () {
     try {
       await connection.serialize()
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_connection_serialize -> 1003')
+      assert.equal(error.code, 1003)
+      assert.equal(error.message, 'vcx_connection_serialize')
     }
   })
 
@@ -80,7 +81,8 @@ describe('A Connection object with ', function () {
     try {
       await connection.serialize()
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_connection_serialize -> 1003')
+      assert.equal(error.code, 1003)
+      assert.equal(error.message, 'vcx_connection_serialize')
     }
   })
 
@@ -99,7 +101,8 @@ describe('A Connection object with ', function () {
     try {
       await Connection.deserialize({source_id: 'Invalid'})
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_connection_deserialize -> 1016')
+      assert.equal(error.code, 1016)
+      assert.equal(error.message, 'vcx_connection_deserialize')
     }
   })
 
@@ -167,7 +170,8 @@ describe('A Connection object with ', function () {
     try {
       await connection.serialize()
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_connection_serialize -> 1003')
+      assert.equal(error.code, 1003)
+      assert.equal(error.message, 'vcx_connection_serialize')
     }
   })
 

--- a/vcx/wrappers/node/test/issuerClaimTest.js
+++ b/vcx/wrappers/node/test/issuerClaimTest.js
@@ -113,7 +113,8 @@ describe('An issuerClaim', async function () {
     try {
       await claim.serialize()
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_issuer_claim_serialize -> ' + Error.INVALID_ISSUER_CLAIM_HANDLE)
+      assert.equal(error.code, Error.INVALID_ISSUER_CLAIM_HANDLE)
+      assert.equal(error.message, 'vcx_issuer_claim_serialize')
     }
   })
 
@@ -153,7 +154,8 @@ describe('An issuerClaim', async function () {
     try {
       await claim.sendClaim(connection)
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_issuer_send_claim -> ' + Error.INVALID_ISSUER_CLAIM_HANDLE)
+      assert.equal(error.code, Error.INVALID_ISSUER_CLAIM_HANDLE)
+      assert.equal(error.message, 'vcx_issuer_send_claim')
     }
   })
 
@@ -165,7 +167,8 @@ describe('An issuerClaim', async function () {
     try {
       await claim.sendClaim(releasedConnection)
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_issuer_send_claim -> ' + Error.INVALID_CONNECTION_HANDLE)
+      assert.equal(error.code, Error.INVALID_CONNECTION_HANDLE)
+      assert.equal(error.message, 'vcx_issuer_send_claim')
     }
   })
 
@@ -174,7 +177,8 @@ describe('An issuerClaim', async function () {
     const sourceId = 'Claim'
     const claim = await IssuerClaim.create({ ...config, sourceId })
     const error = await shouldThrow(() => claim.sendClaim(connection))
-    assert.equal(error.toString(), 'Error: vcx_issuer_send_claim -> ' + Error.NOT_READY)
+    assert.equal(error.code, Error.NOT_READY)
+    assert.equal(error.message, 'vcx_issuer_send_claim')
   })
 
   it('sending claim with valid claim offer should have state VcxStateAccepted', async function () {

--- a/vcx/wrappers/node/test/proofTest.js
+++ b/vcx/wrappers/node/test/proofTest.js
@@ -59,7 +59,8 @@ describe('A Proof', function () {
     try {
       await proof.serialize()
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_proof_serialize -> 1017')
+      assert.equal(error.code, 1017)
+      assert.equal(error.message, 'vcx_proof_serialize')
     }
   })
 
@@ -88,8 +89,9 @@ describe('A Proof', function () {
     const proof = await Proof.create({ sourceId, attrs: ATTR, name: 'TestProof' })
     try {
       await proof.requestProof(connection)
-    } catch (err) {
-      assert.equal(err.toString(), 'Error: vcx_proof_send_request -> 1003')
+    } catch (error) {
+      assert.equal(error.code, 1003)
+      assert.equal(error.message, 'vcx_proof_send_request')
     }
   })
 
@@ -102,8 +104,9 @@ describe('A Proof', function () {
     await proof.release()
     try {
       await proof.requestProof(connection)
-    } catch (err) {
-      assert.equal(err.toString(), 'Error: vcx_proof_send_request -> 1017')
+    } catch (error) {
+      assert.equal(error.code, 1017)
+      assert.equal(error.message, 'vcx_proof_send_request')
     }
   })
 

--- a/vcx/wrappers/node/test/schemaTest.js
+++ b/vcx/wrappers/node/test/schemaTest.js
@@ -61,7 +61,8 @@ describe('A Shema', function () {
     try {
       await schema.serialize()
     } catch (error) {
-      assert.equal(error.toString(), 'Error: vcx_schema_serialize -> 1042')
+      assert.equal(error.code, 1042)
+      assert.equal(error.message, 'vcx_schema_serialize')
     }
   })
 


### PR DESCRIPTION
changed VcxInternalError to contain message and code attributes
Error handling uses this now