### PR TITLE
Retry sending proof req, proof, claim offer, and claim 

### DIFF
--- a/vcx/libvcx/src/messages/get_message.rs
+++ b/vcx/libvcx/src/messages/get_message.rs
@@ -217,6 +217,7 @@ fn get_matching_message(msg_uid:&str, pw_did: &str, pw_vk: &str, agent_did: &str
 
 pub fn get_ref_msg(msg_id: &str, pw_did: &str, pw_vk: &str, agent_did: &str, agent_vk: &str) -> Result<Vec<u8>, u32> {
     let message = get_matching_message(msg_id, pw_did, pw_vk, agent_did, agent_vk)?;
+
     debug!("checking for ref_msg: {:?}", message);
     let msg_id;
     if message.status_code == MessageAccepted.as_string() && !message.ref_msg_id.is_none() {

--- a/vcx/libvcx/src/proof.rs
+++ b/vcx/libvcx/src/proof.rs
@@ -261,7 +261,6 @@ impl Proof {
             return Ok(error::SUCCESS.code_num);
         }
         else if self.state != VcxStateType::VcxStateOfferSent || self.msg_uid.is_empty() || self.prover_did.is_empty() {
-            println!("Offer Sent check");
             return Ok(error::SUCCESS.code_num);
         }
 
@@ -273,6 +272,7 @@ impl Proof {
         };
 
         self.state = VcxStateType::VcxStateAccepted;
+
         match self.proof_validation() {
             Ok(x) => {
                 if self.proof_state != ProofStateType::ProofInvalid {


### PR DESCRIPTION
The ability to retry sending a proof req, proof, claim offer, and claim are now tested and available
The original api calls are used for retry