### PR TITLE
Enforces Strict Dependency to libindy 1.4.0 for libvcx Debian

### DIFF
--- a/vcx/libvcx/Cargo.toml
+++ b/vcx/libvcx/Cargo.toml
@@ -59,7 +59,7 @@ tempfile = "2.2"
 [package.metadata.deb]
 maintainer = "Mark Hadley<mark.hadley@evernym.com>, Devin Fisher, Ryan Marsh, Doug Wightman"
 copyright = "2018, Evernym Inc."
-depends = "$auto, libindy (=1.3)"
+depends = "$auto, libindy (=1.4.0)"
 extended-description = """\
 "TODO DESCRIPTION"""
 section = "admin"


### PR DESCRIPTION
Need to have precise version in the Cargo.toml for the deb metadata fields in Cargo.toml, otherwise install of debian fails.