### PR TITLE
Bug Fix: EN-647 Mask Wallet Key and Small Tweeks

### DIFF
--- a/vcx/ci/Jenkinsfile
+++ b/vcx/ci/Jenkinsfile
@@ -78,8 +78,6 @@ def mainUbuntu() {
                             sh "mkdir -p vcx/output"
                             sh "cp $volumeInternalDir/* vcx/output"
                             sh "ls $volumeInternalDir"
-                            // archiveArtifacts allowEmptyArchive: true, artifacts: 'vcx/output/**/*.tar.gz'
-                            // archiveArtifacts allowEmptyArchive: true, artifacts: 'vcx*.deb'
                             archiveArtifacts allowEmptyArchive: true, artifacts: 'vcx/output/*'
 
                         }

--- a/vcx/ci/Jenkinsfile
+++ b/vcx/ci/Jenkinsfile
@@ -93,6 +93,7 @@ def mainUbuntu() {
                 }
                 echo "$ex error"
             } finally {
+				sh 'docker system df'
                 sh "docker volume rm -f $volumeName"
                 step([$class: 'WsCleanup'])
             }
@@ -127,6 +128,7 @@ def android() {
                 }
                 echo "$ex error"
             } finally {
+				sh 'docker system df'
                 step([$class: 'WsCleanup'])
             }
 
@@ -161,6 +163,8 @@ def ios() {
                 }
                 echo "$ex error"
             } finally {
+				sh 'docker system df'
+				sh 'docker system df'
                 step([$class: 'WsCleanup'])
             }
 

--- a/vcx/libvcx/src/api/utils.rs
+++ b/vcx/libvcx/src/api/utils.rs
@@ -387,12 +387,15 @@ mod tests {
         settings::set_defaults();
         settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE, "true");
 
+
         let json_string = r#"{"agency_url":"https://enym-eagency.pdev.evernym.com","agency_did":"Ab8TvZa3Q19VNkQVzAWVL7","agency_verkey":"5LXaR43B1aQyeh94VBP8LG1Sgvjk7aNfqiksBCSjwqbf","wallet_name":"test_provision_agent","agent_seed":null,"enterprise_seed":null,"wallet_key":"key"}"#;
         let c_json = CString::new(json_string).unwrap().into_raw();
-
-        let result = vcx_agent_provision_async(0, c_json, Some(generic_cb));
+        use utils::libindy::return_types_u32;
+        let cb = return_types_u32::Return_U32_STR::new().unwrap();
+        let result = vcx_agent_provision_async(cb.command_handle, c_json, Some(cb.get_callback()));
         assert_eq!(0, result);
-        thread::sleep(Duration::from_secs(1));
+        let result = cb.receive(Some(Duration::from_secs(2))).unwrap();
+        assert!(result.is_some());
     }
 
     #[test]

--- a/vcx/libvcx/src/messages/agent_utils.rs
+++ b/vcx/libvcx/src/messages/agent_utils.rs
@@ -270,8 +270,6 @@ mod tests {
                                                 None,
                                                 None).unwrap();
         assert!(result.len() > 0);
-        println!("result: {}", result);
-
         wallet::delete_wallet("test_connect_register_provision").unwrap();
     }
 

--- a/vcx/libvcx/src/settings.rs
+++ b/vcx/libvcx/src/settings.rs
@@ -11,7 +11,6 @@ use std::fs;
 use std::io::prelude::*;
 use serde_json::Value;
 
-
 pub static CONFIG_POOL_NAME: &'static str = "pool_name";
 pub static CONFIG_WALLET_NAME: &'static str = "wallet_name";
 pub static CONFIG_WALLET_TYPE: &'static str = "wallet_type";
@@ -47,11 +46,22 @@ pub static DEFAULT_DID: &str = "2hoqvcwupRTUNkXn6ArYzs";
 pub static DEFAULT_VERKEY: &str = "FuN98eH2eZybECWkofW6A9BKJxxnTatBCopfUiNxo6ZB";
 pub static DEFAULT_ENABLE_TEST_MODE: &str = "false";
 pub static TEST_WALLET_KEY: &str = "key";
-
+pub static MASK_VALUE: &str = "********";
 lazy_static! {
     static ref SETTINGS: RwLock<HashMap<String, String>> = RwLock::new(HashMap::new());
 }
 
+trait ToString {
+    fn to_string(&self) -> Self;
+}
+
+impl ToString for HashMap<String, String> {
+    fn to_string(&self) -> Self {
+        let mut v = self.clone();
+        v.insert(CONFIG_WALLET_KEY.to_string(), "********".to_string());
+        v
+    }
+}
 pub fn set_defaults() -> u32 {
 
     // if this fails the program should exit
@@ -132,7 +142,7 @@ fn validate_optional_config_val<F, S, E>(val: Option<&String>, err: u32, closure
 
 pub fn log_settings() {
     let settings = SETTINGS.read().unwrap();
-    trace!("loaded settings: {:?}", settings);
+    trace!("loaded settings: {:?}", settings.to_string());
 }
 
 pub fn test_indy_mode_enabled() -> bool {
@@ -448,5 +458,25 @@ pub mod tests {
         assert_eq!(get_config_value("institution_name"), Err(error::INVALID_CONFIGURATION.code_num));
         assert_eq!(get_config_value("genesis_path"), Err(error::INVALID_CONFIGURATION.code_num));
         assert_eq!(get_config_value("wallet_key"), Err(error::INVALID_CONFIGURATION.code_num));
+    }
+
+    #[test]
+    fn test_log_settings() {
+        // log settings should mask the wallet_key field
+        ::utils::logger::LoggerUtils::init_test_logging("trace");
+        set_defaults();
+        let key = "secretkeyabc123foobar";
+        {
+            let mut settings = SETTINGS.write().unwrap();
+            settings.insert(CONFIG_WALLET_KEY.to_string(), key.to_string()).unwrap();
+            let masked_settings = settings.to_string();
+            match masked_settings.get(CONFIG_WALLET_KEY) {
+                None => panic!("Test Failure"),
+                Some(value) => {
+                    assert_ne!(value, key);
+                },
+            }
+        }
+        log_settings();
     }
 }

--- a/vcx/libvcx/src/utils/libindy/payments.rs
+++ b/vcx/libvcx/src/utils/libindy/payments.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use settings;
 
 static EMPTY_CONFIG: &str = "{}";
-static DEFAULT_FEES: &str = r#"{"0":0, "1":0, "101":2, "102":42, "103":0, "104":0, "105":0, "106":0, "107":0, "108":0, "109":0, "110":0, "111":0, "112":0, "113":0, "114":0, "115":0, "116":0, "117":0, "118":0, "119":0}"#;
+static DEFAULT_FEES: &str = r#"{"0":0, "1":0, "101":2, "102":42, "103":0, "104":0, "105":0, "107":0, "108":0, "109":0, "110":0, "111":0, "112":0, "113":0, "114":0, "115":0, "116":0, "117":0, "118":0, "119":0}"#;
 static PARSED_TXN_PAYMENT_RESPONSE: &str = r#"[{"amount":4,"extra":null,"input":"["pov:null:1","pov:null:2"]"}]"#;
 
 static PAYMENT_INIT: Once = ONCE_INIT;

--- a/vcx/wrappers/node/src/api/common.ts
+++ b/vcx/wrappers/node/src/api/common.ts
@@ -99,7 +99,7 @@ export interface IInitVCXOptions {
 
 export interface IUTXO {
   paymentAddress: string,
-  amount: string,
+  amount: number,
   extra?: string,
   txo?: string
 }


### PR DESCRIPTION
This mainly fixes EN-647 bug, which masks the wallet key from logging.
Also reverts some changes to variables in PR #355 (requested by @keenondrums 
Added some docker system disk usage during cleanup to help diagnose our problem when filling up the Jenkins machines.
Refactors a rust test to use Callbacks in testing.