### PR TITLE
Cocoapod with latest libvcx, libindy & libnullpay

### DIFF
--- a/Specs/vcx/0.0.22/vcx.podspec
+++ b/Specs/vcx/0.0.22/vcx.podspec
@@ -1,0 +1,44 @@
+#
+# Be sure to run `pod lib lint vcx.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'vcx'
+  s.version          = '0.0.22'
+  s.summary          = 'The Objective-C wrapper around the libvcx shared library.'
+
+# This description is used to generate tags and improve search results.
+#   * Think: What does it do? Why did you write it? What is the focus?
+#   * Try to keep it short, snappy and to the point.
+#   * Write the description between the DESC delimiters below.
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+
+  s.description      = <<-DESC
+The ConnectMe mobile app on the iOS platform will call into the libvcx shared library
+from Objective-C. This pod is a very thin Objective-C wrapper that allows react native to call
+through to the libvcx shared library.
+                       DESC
+
+  s.homepage         = 'https://www.evernym.com/'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'evernym-ios-dev' => 'iosdev@evernym.com' }
+  s.source           = { :http => 'https://repo.corp.evernym.com/filely/ios/vcx.framework_20180723.2003_universal.zip' }
+
+  s.ios.deployment_target = '8.0'
+
+  #s.source_files = '**/vcx/Classes/**/*','**/Example/Classes/**/*'
+  
+  # s.resource_bundles = {
+  #   'vcx' => ['**/vcx/Assets/*.png']
+  # }
+  s.ios.vendored_frameworks="vcx/vcx.framework"
+  s.compiler_flags = '-ObjC'
+  s.public_header_files = 'vcx/vcx.framework/include/*.h'
+  s.ios.vendored_library = 'vcx/vcx.framework/lib/libvcx.a'
+  # s.frameworks = 'UIKit', 'MapKit'
+  # s.dependency 'AFNetworking', '~> 2.3'
+end

--- a/Specs/vcx/0.0.23/vcx.podspec
+++ b/Specs/vcx/0.0.23/vcx.podspec
@@ -1,0 +1,44 @@
+#
+# Be sure to run `pod lib lint vcx.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'vcx'
+  s.version          = '0.0.22'
+  s.summary          = 'The Objective-C wrapper around the libvcx shared library.'
+
+# This description is used to generate tags and improve search results.
+#   * Think: What does it do? Why did you write it? What is the focus?
+#   * Try to keep it short, snappy and to the point.
+#   * Write the description between the DESC delimiters below.
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+
+  s.description      = <<-DESC
+The ConnectMe mobile app on the iOS platform will call into the libvcx shared library
+from Objective-C. This pod is a very thin Objective-C wrapper that allows react native to call
+through to the libvcx shared library.
+                       DESC
+
+  s.homepage         = 'https://www.evernym.com/'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'evernym-ios-dev' => 'iosdev@evernym.com' }
+  s.source           = { :http => 'https://repo.corp.evernym.com/filely/ios/vcx.framework_20180723.2026_universal.zip' }
+
+  s.ios.deployment_target = '8.0'
+
+  #s.source_files = '**/vcx/Classes/**/*','**/Example/Classes/**/*'
+  
+  # s.resource_bundles = {
+  #   'vcx' => ['**/vcx/Assets/*.png']
+  # }
+  s.ios.vendored_frameworks="vcx/vcx.framework"
+  s.compiler_flags = '-ObjC'
+  s.public_header_files = 'vcx/vcx.framework/include/*.h'
+  s.ios.vendored_library = 'vcx/vcx.framework/lib/libvcx.a'
+  # s.frameworks = 'UIKit', 'MapKit'
+  # s.dependency 'AFNetworking', '~> 2.3'
+end

--- a/Specs/vcx/0.0.23/vcx.podspec
+++ b/Specs/vcx/0.0.23/vcx.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'vcx'
-  s.version          = '0.0.22'
+  s.version          = '0.0.23'
   s.summary          = 'The Objective-C wrapper around the libvcx shared library.'
 
 # This description is used to generate tags and improve search results.

--- a/vcx/libvcx/build_scripts/android/mac/debug/mac.09.x86.combine.shared.libs.sh
+++ b/vcx/libvcx/build_scripts/android/mac/debug/mac.09.x86.combine.shared.libs.sh
@@ -31,10 +31,7 @@ do
     rm ./libvcx.so
     $NDK_DIR/${ndk_arch}/bin/${cross_compile}-clang -v -shared -o libvcx.so -Wl,--whole-archive \
     libvcx.a \
-    libcrypto.a \
     libsodium.a \
-    libsqlite3.a \
-    libssl.a \
     libzmq.a \
     $NDK_DIR/${ndk_arch}/${cross_compile}/${LIB_FOLDER}/libgnustl_shared.so \
     $NDK_DIR/${ndk_arch}/sysroot/usr/${LIB_FOLDER}/libz.so \

--- a/vcx/libvcx/build_scripts/android/mac/debug/mac.09.x86.combine.shared.libs.sh
+++ b/vcx/libvcx/build_scripts/android/mac/debug/mac.09.x86.combine.shared.libs.sh
@@ -31,7 +31,9 @@ do
     rm ./libvcx.so
     $NDK_DIR/${ndk_arch}/bin/${cross_compile}-clang -v -shared -o libvcx.so -Wl,--whole-archive \
     libvcx.a \
+    libcrypto.a \
     libsodium.a \
+    libssl.a \
     libzmq.a \
     $NDK_DIR/${ndk_arch}/${cross_compile}/${LIB_FOLDER}/libgnustl_shared.so \
     $NDK_DIR/${ndk_arch}/sysroot/usr/${LIB_FOLDER}/libz.so \

--- a/vcx/libvcx/build_scripts/android/mac/mac.03.libindy.build.sh
+++ b/vcx/libvcx/build_scripts/android/mac/mac.03.libindy.build.sh
@@ -30,9 +30,6 @@ cd $WORK_DIR/vcx-indy-sdk/libindy
 export LIBZMQ_LIB_DIR=/usr/local/lib
 export LIBZMQ_INCLUDE_DIR=/usr/local/include
 sed -i .bak 's/LIBZMQ_LIB_DIR/ANDROID_ZMQ_LIB/' build.rs
-# !IMPORTANT STEPS NEXT -- Modify the build.rs of indy-sdk to handle android shared libraries
-tail -n 1 build.rs | wc -c | xargs -I {} truncate build.rs -s -{}
-cat $START_DIR/indy-sdk.build.rs.android.target.static.libs.template >> build.rs
 ###################################################################################################
 
 if [ ! -d $WORK_DIR/libzmq-android/libsodium/libsodium_arm ]; then
@@ -85,24 +82,23 @@ export ORIGINAL_PATH=$PATH
 #export ORIGINAL_PKG_CONFIG_PATH=$PKG_CONFIG_PATH
 
 cargo clean
-cargo install
 
 export OPENSSL_DIR_DARWIN=$OPENSSL_DIR
 
 #########################################################################################################################
 # Now build libindy
 #########################################################################################################################
-export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi; echo "OPENSSL_DIR: $OPENSSL_DIR"
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
-export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
-#export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
-#export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
-export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/armeabi-v7a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
-sed -i .bak 's/\"\"\.as_ptr() as \*const i8/\"\"\.as_ptr() as \*const u8/' src/services/wallet/storage/plugged/mod.rs
-cargo build --target arm-linux-androideabi --release --verbose
-echo "-----------------------------------------------------------------------------------------------"
+# export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi; echo "OPENSSL_DIR: $OPENSSL_DIR"
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
+# export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
+# #export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
+# #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
+# export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/armeabi-v7a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
+# sed -i .bak 's/\"\"\.as_ptr() as \*const i8/\"\"\.as_ptr() as \*const u8/' src/services/wallet/storage/plugged/mod.rs
+# cargo build --target arm-linux-androideabi --release --verbose
+# echo "-----------------------------------------------------------------------------------------------"
 
 export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
 export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi-v7a; echo "OPENSSL_DIR: $OPENSSL_DIR"
@@ -116,17 +112,17 @@ sed -i .bak 's/\"\"\.as_ptr() as \*const i8/\"\"\.as_ptr() as \*const u8/' src/s
 cargo build --target armv7-linux-androideabi --release --verbose
 echo "-----------------------------------------------------------------------------------------------"
 
-export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-arm64-v8a; echo "OPENSSL_DIR: $OPENSSL_DIR"
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
-export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
-#export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
-#export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
-export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/arm64-v8a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
-sed -i .bak 's/\"\"\.as_ptr() as \*const i8/\"\"\.as_ptr() as \*const u8/' src/services/wallet/storage/plugged/mod.rs
-cargo build --target aarch64-linux-android --release --verbose
-echo "-----------------------------------------------------------------------------------------------"
+# export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-arm64-v8a; echo "OPENSSL_DIR: $OPENSSL_DIR"
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
+# export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
+# #export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
+# #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
+# export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/arm64-v8a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
+# sed -i .bak 's/\"\"\.as_ptr() as \*const i8/\"\"\.as_ptr() as \*const u8/' src/services/wallet/storage/plugged/mod.rs
+# cargo build --target aarch64-linux-android --release --verbose
+# echo "-----------------------------------------------------------------------------------------------"
 
 export PATH=$WORK_DIR/NDK/x86/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
 export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86; echo "OPENSSL_DIR: $OPENSSL_DIR"
@@ -140,17 +136,17 @@ sed -i .bak 's/\"\"\.as_ptr() as \*const u8/\"\"\.as_ptr() as \*const i8/' src/s
 cargo build --target i686-linux-android --release --verbose
 echo "-----------------------------------------------------------------------------------------------"
 
-export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86_64; echo "OPENSSL_DIR: $OPENSSL_DIR"
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_x86_64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
-export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
-#export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
-#export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
-export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/x86_64; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
-sed -i .bak 's/\"\"\.as_ptr() as \*const u8/\"\"\.as_ptr() as \*const i8/' src/services/wallet/storage/plugged/mod.rs
-cargo build --target x86_64-linux-android --release --verbose
-echo "-----------------------------------------------------------------------------------------------"
+# export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86_64; echo "OPENSSL_DIR: $OPENSSL_DIR"
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_x86_64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
+# export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
+# #export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
+# #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
+# export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/x86_64; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
+# sed -i .bak 's/\"\"\.as_ptr() as \*const u8/\"\"\.as_ptr() as \*const i8/' src/services/wallet/storage/plugged/mod.rs
+# cargo build --target x86_64-linux-android --release --verbose
+# echo "-----------------------------------------------------------------------------------------------"
 
 # This builds the library for code that runs in OSX
 export OPENSSL_DIR=$OPENSSL_DIR_DARWIN
@@ -170,26 +166,24 @@ echo "--------------------------------------------------------------------------
 #########################################################################################################################
 cd $WORK_DIR/vcx-indy-sdk/libnullpay
 
-# KS: Don't need to replace it now, "staticlib" is now added in cargo.toml for libNullpay
-# # Replace '\"cdylib\"' with '\"staticlib\", \"cdylib\"' in Cargo.toml
-sed -i .bak 's/\"cdylib\"/\"staticlib\", \"cdylib\"/' Cargo.toml
+cargo clean
 
 # !IMPORTANT STEPS NEXT -- Modify the build.rs of libnullpay to handle android shared libraries
 tail -n 1 build.rs | wc -c | xargs -I {} truncate build.rs -s -{}
 cat $START_DIR/libnullpay.build.rs.android.target.static.libs.template >> build.rs
 ###################################################################################################
 
-export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi; echo "OPENSSL_DIR: $OPENSSL_DIR"
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
-export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
-#export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
-#export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
-export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/armeabi-v7a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
-export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/arm-linux-androideabi/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
-cargo build --target arm-linux-androideabi --release --verbose
-echo "-----------------------------------------------------------------------------------------------"
+# export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi; echo "OPENSSL_DIR: $OPENSSL_DIR"
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
+# export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
+# #export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
+# #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
+# export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/armeabi-v7a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
+# export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/arm-linux-androideabi/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
+# cargo build --target arm-linux-androideabi --release --verbose
+# echo "-----------------------------------------------------------------------------------------------"
 
 export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
 export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi-v7a; echo "OPENSSL_DIR: $OPENSSL_DIR"
@@ -203,17 +197,17 @@ export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/armv7-linux-androideabi
 cargo build --target armv7-linux-androideabi --release --verbose
 echo "-----------------------------------------------------------------------------------------------"
 
-export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-arm64-v8a; echo "OPENSSL_DIR: $OPENSSL_DIR"
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
-export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
-#export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
-#export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
-export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/arm64-v8a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
-export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/aarch64-linux-android/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
-cargo build --target aarch64-linux-android --release --verbose
-echo "-----------------------------------------------------------------------------------------------"
+# export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-arm64-v8a; echo "OPENSSL_DIR: $OPENSSL_DIR"
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
+# export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
+# #export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
+# #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
+# export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/arm64-v8a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
+# export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/aarch64-linux-android/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
+# cargo build --target aarch64-linux-android --release --verbose
+# echo "-----------------------------------------------------------------------------------------------"
 
 export PATH=$WORK_DIR/NDK/x86/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
 export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86; echo "OPENSSL_DIR: $OPENSSL_DIR"
@@ -227,28 +221,23 @@ export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/i686-linux-android/rele
 cargo build --target i686-linux-android --release --verbose
 echo "-----------------------------------------------------------------------------------------------"
 
-export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86_64; echo "OPENSSL_DIR: $OPENSSL_DIR"
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_x86_64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
-export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
-#export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
-#export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
-export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/x86_64; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
-export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/x86_64-linux-android/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
-cargo build --target x86_64-linux-android --release --verbose
-echo "-----------------------------------------------------------------------------------------------"
+# export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86_64; echo "OPENSSL_DIR: $OPENSSL_DIR"
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_x86_64/lib; echo "ANDROID_SODIUM_LIB: $ANDROID_SODIUM_LIB"
+# export SODIUM_LIB_DIR=$ANDROID_SODIUM_LIB; echo "SODIUM_LIB_DIR: $SODIUM_LIB_DIR"
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/lib; echo "ANDROID_ZMQ_LIB: $ANDROID_ZMQ_LIB"
+# #export LIBZMQ_LIB_DIR=$ANDROID_ZMQ_LIB; echo "LIBZMQ_LIB_DIR: $LIBZMQ_LIB_DIR"
+# #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
+# export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/x86_64; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
+# export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/x86_64-linux-android/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
+# cargo build --target x86_64-linux-android --release --verbose
+# echo "-----------------------------------------------------------------------------------------------"
 
 # This builds the library for code that runs in OSX
 export OPENSSL_DIR=$OPENSSL_DIR_DARWIN
-#unset LIBZMQ_LIB_DIR
-#unset LIBZMQ_INCLUDE_DIR
 unset ANDROID_SODIUM_LIB
 SODIUM_LIB_DIR=/usr/local/lib
 ANDROID_ZMQ_LIB=/usr/local/lib
 unset ANDROID_SQLITE_LIB
-# KS:Commenting this for now, because it fails for osx build
-# cargo build --target x86_64-apple-darwin --release --verbose
 
 export PATH=$ORIGINAL_PATH
-#export PKG_CONFIG_PATH=$ORIGINAL_PKG_CONFIG_PATH

--- a/vcx/libvcx/build_scripts/android/mac/mac.06.libvcx.build.sh
+++ b/vcx/libvcx/build_scripts/android/mac/mac.06.libvcx.build.sh
@@ -11,20 +11,20 @@ source ./mac.05.libvcx.env.sh
 cd ../../..
 
 export ORIGINAL_PATH=$PATH
-#export ORIGINAL_PKG_CONFIG_PATH=$PKG_CONFIG_PATH
-
-cargo clean
-cargo install
-
 export OPENSSL_DIR_DARWIN=$OPENSSL_DIR
 
-export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm/lib
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm/lib
-export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/arm-linux-androideabi/release
-export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/arm-linux-androideabi/release
-cargo build --target arm-linux-androideabi --release --verbose
+cargo clean
+
+# Disable libnullpay calls
+# sed -i -n 's/unsafe { nullpay_init() }/unsafe { 0 }/p' src/utils/libindy/payments.rs
+
+# export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm/lib
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm/lib
+# export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/arm-linux-androideabi/release
+# export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/arm-linux-androideabi/release
+# cargo build --target arm-linux-androideabi --release --verbose
 
 export PATH=$WORK_DIR/NDK/arm/bin:$ORIGINAL_PATH
 export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-armeabi-v7a
@@ -32,15 +32,15 @@ export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_armv7/lib
 export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_armv7/lib
 export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/armv7-linux-androideabi/release
 export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/armv7-linux-androideabi/release
-cargo build --target armv7-linux-androideabi --release --verbose
+cargo build --target armv7-linux-androideabi --release
 
-export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-arm64-v8a
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm64/lib
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/lib
-export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/aarch64-linux-android/release
-export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/aarch64-linux-android/release
-cargo build --target aarch64-linux-android --release --verbose
+# export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-arm64-v8a
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_arm64/lib
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_arm64/lib
+# export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/aarch64-linux-android/release
+# export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/aarch64-linux-android/release
+# cargo build --target aarch64-linux-android --release --verbose
 
 export PATH=$WORK_DIR/NDK/x86/bin:$ORIGINAL_PATH
 export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86
@@ -48,45 +48,18 @@ export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_x86/lib
 export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86/lib
 export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/i686-linux-android/release
 export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/i686-linux-android/release
-cargo build --target i686-linux-android --release --verbose
+cargo build --target i686-linux-android --release
 
-export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH
-export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86_64
-export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_x86_64/lib
-export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/lib
-export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/x86_64-linux-android/release
-export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/x86_64-linux-android/release
-cargo build --target x86_64-linux-android --release --verbose
+# export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH
+# export OPENSSL_DIR=$WORK_DIR/openssl_for_ios_and_android/output/android/openssl-x86_64
+# export ANDROID_SODIUM_LIB=$WORK_DIR/libzmq-android/libsodium/libsodium_x86_64/lib
+# export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86_64/lib
+# export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/x86_64-linux-android/release
+# export LIBNULLPAY_DIR=$WORK_DIR/vcx-indy-sdk/libnullpay/target/x86_64-linux-android/release
+# cargo build --target x86_64-linux-android --release --verbose
 
-# This builds the library for code that runs in OSX
-ln -sf $WORK_DIR/vcx-indy-sdk/libindy/target/x86_64-apple-darwin/release/libindy.dylib /usr/local/lib/libindy.dylib
-ln -sf $WORK_DIR/vcx-indy-sdk/libnullpay/target/x86_64-apple-darwin/release/libnullpay.dylib /usr/local/lib/libnullpay.dylib
 export PATH=$ORIGINAL_PATH
 export OPENSSL_DIR=$OPENSSL_DIR_DARWIN
 unset ANDROID_SODIUM_LIB
 unset ANDROID_ZMQ_LIB
 unset LIBINDY_DIR
-# cargo build --target x86_64-apple-darwin --release --verbose
-
-#cargo test
-
-#export PKG_CONFIG_PATH=$ORIGINAL_PKG_CONFIG_PATH
-
-
-
-
-
-
-
-
-# To build for macos
-#cargo build
-#export LIBINDY_DIR=/usr/local/lib
-#export RUST_BACKTRACE=1
-# To build for iOS
-#LIBINDY_DIR=/usr/local/lib RUST_BACKTRACE=1 cargo lipo --release
-
-#cargo lipo --release --verbose --targets="aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios"
-
-#LIBINDY_DIR=/usr/local/lib RUST_BACKTRACE=1 cargo lipo
-#LIBINDY_DIR=/usr/local/lib cargo test

--- a/vcx/libvcx/build_scripts/android/mac/mac.08.copy.shared.libs.to.app.sh
+++ b/vcx/libvcx/build_scripts/android/mac/mac.08.copy.shared.libs.to.app.sh
@@ -12,12 +12,20 @@ INDY_SDK=$WORK_DIR/vcx-indy-sdk
 VCX_SDK=$START_DIR/../../../../..
 VCX_SDK=$(abspath "$VCX_SDK")
 
+# Remove existing architecture builds from jniLibs
+rm -rf $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/*
+
+# declare -a archs=(
+#     "arm" "arm" "arm-linux-androideabi" "armeabi-v7a"
+#     "arm" "armv7" "armv7-linux-androideabi" "armeabi-v7a"
+#     "arm64" "arm64" "aarch64-linux-android" "arm64-v8a"
+#     "x86" "x86" "i686-linux-android" "x86"
+#     "x86_64" "x86_64" "x86_64-linux-android" "x86_64"
+#     )
+# For now we just want armv7 and x86 builds
 declare -a archs=(
-    "arm" "arm" "arm-linux-androideabi" "armeabi-v7a"
     "arm" "armv7" "armv7-linux-androideabi" "armeabi-v7a"
-    "arm64" "arm64" "aarch64-linux-android" "arm64-v8a"
     "x86" "x86" "i686-linux-android" "x86"
-    "x86_64" "x86_64" "x86_64-linux-android" "x86_64"
     )
 archslen=${#archs[@]}
 
@@ -31,11 +39,10 @@ do
     mkdir -p $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
     ln -f -v $OPENSSL_DIR/output/android/openssl-${openssl_arch}/lib/libssl.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
     ln -f -v $OPENSSL_DIR/output/android/openssl-${openssl_arch}/lib/libcrypto.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
-    ln -f -v $INDY_SDK/libnullpay/target/${cross_compile}/release/libnullpay.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
-    ln -f -v $INDY_SDK/libindy/target/${cross_compile}/release/libindy.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
+    # ln -f -v $INDY_SDK/libnullpay/target/${cross_compile}/release/libnullpay.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
+    # ln -f -v $INDY_SDK/libindy/target/${cross_compile}/release/libindy.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
     ln -f -v $VCX_SDK/vcx/libvcx/target/${cross_compile}/release/libvcx.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
     ln -f -v $WORK_DIR/libzmq-android/libsodium/libsodium_${target_arch}/lib/libsodium.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
     ln -f -v $WORK_DIR/libzmq-android/zmq/libzmq_${target_arch}/lib/libzmq.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
-    ln -f -v $WORK_DIR/libz-android/zlib/lib/${target_arch}/libz.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
-    ln -f -v $WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/${openssl_arch}/libsqlite3.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
+    # ln -f -v $WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/${openssl_arch}/libsqlite3.a $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
 done

--- a/vcx/libvcx/build_scripts/android/mac/mac.09.combine.shared.libs.sh
+++ b/vcx/libvcx/build_scripts/android/mac/mac.09.combine.shared.libs.sh
@@ -12,12 +12,17 @@ INDY_SDK=$WORK_DIR/vcx-indy-sdk
 VCX_SDK=$START_DIR/../../../../..
 VCX_SDK=$(abspath "$VCX_SDK")
 
+# declare -a archs=(
+#     "arm" "arm" "arm-linux-androideabi" "armeabi"
+#     "arm" "armv7" "arm-linux-androideabi" "armeabi-v7a"
+#     "arm64" "arm64" "aarch64-linux-android" "arm64-v8a"
+#     "x86" "x86" "i686-linux-android" "x86"
+#     "x86_64" "x86_64" "x86_64-linux-android" "x86_64"
+#     )
+# For now, we need only two architectures
 declare -a archs=(
-    "arm" "arm" "arm-linux-androideabi" "armeabi"
     "arm" "armv7" "arm-linux-androideabi" "armeabi-v7a"
-    "arm64" "arm64" "aarch64-linux-android" "arm64-v8a"
     "x86" "x86" "i686-linux-android" "x86"
-    "x86_64" "x86_64" "x86_64-linux-android" "x86_64"
     )
 archslen=${#archs[@]}
 
@@ -39,11 +44,11 @@ do
     cd $VCX_SDK/vcx/wrappers/java/vcx/src/main/jniLibs/${target_arch}
     rm ./libvcx.so
     $NDK_DIR/${ndk_arch}/bin/${cross_compile}-clang -v -shared -o libvcx.so -Wl,--whole-archive \
-    libindy.a \
-    libnullpay.a \
     libvcx.a \
     libzmq.a \
     libsodium.a \
+    libssl.a \
+    libcrypto.a \
     ${LIB_GNUSTL} \
     $NDK_DIR/${ndk_arch}/sysroot/usr/${LIB_FOLDER}/libz.so \
     $NDK_DIR/${ndk_arch}/sysroot/usr/${LIB_FOLDER}/libm.a \

--- a/vcx/libvcx/build_scripts/android/mac/mac.upload.android.build.zipfiles.sh
+++ b/vcx/libvcx/build_scripts/android/mac/mac.upload.android.build.zipfiles.sh
@@ -9,38 +9,8 @@ WORK_DIR=$(abspath "$WORK_DIR")
 VCX_SDK=$START_DIR/../../../../..
 VCX_SDK=$(abspath "$VCX_SDK")
 
-# DATETIME=$1
-# if [ "$DATETIME" = "" ]; then
-#     echo "You must pass the datetime as the first parameter to the script. (i.e. 20180522.1354 - YYYYmmdd.hhMM)"
-#     exit 1
-# fi
-
-# cd $VCX_SDK/vcx/wrappers/java/android/vcxtest/app/jni
-
-# mv libvcxall_arm.zip libvcxall_${DATETIME}_arm.zip
-# curl --insecure -u normjarvis -X POST -F file=@./libvcxall_${DATETIME}_arm.zip https://kraken.corp.evernym.com/repo/android/upload
-# sudo cp -v ./libvcxall_${DATETIME}_arm.zip  /usr/local/var/www/download/android
-
-# mv libvcxall_arm64.zip libvcxall_${DATETIME}_arm64.zip
-# curl --insecure -u normjarvis -X POST -F file=@./libvcxall_${DATETIME}_arm64.zip https://kraken.corp.evernym.com/repo/android/upload
-# sudo cp -v ./libvcxall_${DATETIME}_arm64.zip  /usr/local/var/www/download/android
-
-# mv libvcxall_armv7.zip libvcxall_${DATETIME}_armv7.zip
-# curl --insecure -u normjarvis -X POST -F file=@./libvcxall_${DATETIME}_armv7.zip https://kraken.corp.evernym.com/repo/android/upload
-# sudo cp -v ./libvcxall_${DATETIME}_armv7.zip  /usr/local/var/www/download/android
-
-# mv libvcxall_x86.zip libvcxall_${DATETIME}_x86.zip
-# curl --insecure -u normjarvis -X POST -F file=@./libvcxall_${DATETIME}_x86.zip https://kraken.corp.evernym.com/repo/android/upload
-# sudo cp -v ./libvcxall_${DATETIME}_x86.zip  /usr/local/var/www/download/android
-
-# mv libvcxall_x86_64.zip libvcxall_${DATETIME}_x86-64.zip
-# curl --insecure -u normjarvis -X POST -F file=@./libvcxall_${DATETIME}_x86-64.zip https://kraken.corp.evernym.com/repo/android/upload
-# sudo cp -v ./libvcxall_${DATETIME}_x86-64.zip  /usr/local/var/www/download/android
-
-
-# rm libvcxall_${target_arch}.zip
 cd $VCX_SDK/vcx/wrappers/java/vcx/
-sed -i .bak 's/evernym/androidbuild1/g' local.properties
+# sed -i .bak 's/evernym/androidbuild1/g' local.properties
 ./gradlew clean assembleDebug
 cd $VCX_SDK/vcx/wrappers/java/vcx/build/outputs/aar/
 AAR_FILE=$(ls *-debug.aar)
@@ -59,7 +29,3 @@ mvn install:install-file -Dfile=${AAR_FILE} -DgroupId=com.connectme \
 # cp $VCX_SDK/vcx/wrappers/java/android/vcxtest/app/jni/x86/*.so ./jni/x86
 # cp $VCX_SDK/vcx/wrappers/java/android/vcxtest/app/jni/arm64/*.so ./jni/arm64
 # cp $VCX_SDK/vcx/wrappers/java/android/vcxtest/app/jni/x86_64/*.so ./jni/x86_64
-
-# zip -r vcx_1.0.0-${DATETIME}_all.aar *
-#curl --insecure -u normjarvis -X POST -F file=@./${AAR_FILE} https://kraken.corp.evernym.com/repo/android/upload
-#sudo cp ./${AAR_FILE}  /usr/local/var/www/download/android

--- a/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/proof/ProofApi.java
+++ b/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/proof/ProofApi.java
@@ -202,5 +202,4 @@ public class ProofApi extends VcxJava.API {
         return future;
     }
 
-
 }


### PR DESCRIPTION
- Updated android build scripts to only build for armv7 and x86 because these are the only architectures that we are supporting as of now
- Removed libsqlite from final static binary because it is already linked in libindy statically
- Cocoapod 0.0.22 has all architectures in it
- Cocoapod 0.0.23 has only armv7 and arm64 architecture binaries