### PR TITLE
Use prebuilt libindy and libnullpay.

### DIFF
--- a/vcx/ci/Jenkinsfile
+++ b/vcx/ci/Jenkinsfile
@@ -179,10 +179,15 @@ def fail() {
 
 def buildAndroid(envn) {
     envn.inside {
+        LIBINDY_BRANCH="master"
+        LIBINDY_VERSION="1.5.0-619"
+        LIBNULLPAY_BRANCH="master"
+        LIBNULLPAY_VERSION="1.5.0-619"
+
         ANDROID_SCRIPT_PATH = 'vcx/ci/scripts/androidBuild.sh'
-        sh "./${ANDROID_SCRIPT_PATH} arm"
-        sh "./${ANDROID_SCRIPT_PATH} x86"
-        //sh "./${ANDROID_SCRIPT_PATH} arm64"
+        sh "LIBINDY_BRANCH=${LIBINDY_BRANCH} LIBINDY_VERSION=${LIBINDY_VERSION} LIBNULLPAY_BRANCH=${LIBNULLPAY_BRANCH} LIBNULLPAY_VERSION=${LIBNULLPAY_VERSION} ./${ANDROID_SCRIPT_PATH} arm"
+        sh "LIBINDY_BRANCH=${LIBINDY_BRANCH} LIBINDY_VERSION=${LIBINDY_VERSION} LIBNULLPAY_BRANCH=${LIBNULLPAY_BRANCH} LIBNULLPAY_VERSION=${LIBNULLPAY_VERSION} ./${ANDROID_SCRIPT_PATH} x86"
+//        sh "LIBINDY_BRANCH=${LIBINDY_BRANCH} LIBINDY_VERSION=${LIBINDY_VERSION} LIBNULLPAY_BRANCH=${LIBNULLPAY_BRANCH} LIBNULLPAY_VERSION=${LIBNULLPAY_VERSION} ./${ANDROID_SCRIPT_PATH} arm64"
         //Todo: get parallel processing to work. Currently it fails on Jenkins. It must share files or something
         // parallel([
         //     'arm': { sh "./${ANDROID_SCRIPT_PATH} arm"},

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -104,12 +104,8 @@ generate_flags(){
 
 get_libindy() {
     set -xv
-    wget https://transfer.sh/73l3U/libindy_android_x86.zip
-    unzip libindy_android_x86.zip
-    wget https://transfer.sh/cssbl/libindy_android_arm64.zip
-    unzip libindy_android_arm64.zip
-    wget https://transfer.sh/TbH7L/libindy_android_arm.zip
-    unzip libindy_android_arm.zip
+    wget https://transfer.sh/73l3U/libindy_android_${ARCH}.zip
+    unzip libindy_android_${ARCH}.zip
 
 }
 

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -117,7 +117,7 @@ get_libindy() {
     [ -z ${LIBINDY_VERSION} ] && exit 1
 
     wget https://repo.sovrin.org/android/libindy/${LIBINDY_BRANCH}/${LIBINDY_VERSION}/libindy_android_${ARCH}_${LIBINDY_VERSION}.zip
-    unzip libindy_android_${ARCH}.${LIBINDY_VERSION}.zip
+    unzip libindy_android_${ARCH}_${LIBINDY_VERSION}.zip
 
 }
 

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -125,7 +125,7 @@ get_libnullpay() {
     set -xv
     [ -z ${LIBNULLPAY_BRANCH} ] && exit 1
     [ -z ${LIBNULLPAY_VERSION} ] && exit 1
-    wget https://repo.sovrin.org/android/libnullpay/${LIBNULLPAY_BRANCH}/${LIBNULLPAY_VERSION}/libnullpay_android_${ARCH}_${LIBNULLPAY_VERSION}.zip
+    wget https://repo.sovrin.org/android/libnullpay/${LIBNULLPAY_BRANCH}/${LIBNULLPAY_VERSION}/libnullpay_android_${ARCH}.${LIBNULLPAY_VERSION}.zip
     unzip libnullpay_android_${ARCH}.${LIBNULLPAY_VERSION}.zip
 
 }

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -117,7 +117,7 @@ get_libindy() {
     [ -z ${LIBINDY_VERSION} ] && exit 1
 
     wget https://repo.sovrin.org/android/libindy/${LIBINDY_BRANCH}/${LIBINDY_VERSION}/libindy_android_${ARCH}_${LIBINDY_VERSION}.zip
-    unzip libindy_android_${ARCH}_1.5.0.zip
+    unzip libindy_android_${ARCH}_${LIBINDY_VERSION}.zip
 
 }
 
@@ -126,7 +126,7 @@ get_libnullpay() {
     [ -z ${LIBNULLPAY_BRANCH} ] && exit 1
     [ -z ${LIBNULLPAY_VERSION} ] && exit 1
     wget https://repo.sovrin.org/android/libnullpay/${LIBNULLPAY_BRANCH}/${LIBNULLPAY_VERSION}/libnullpay_android_${ARCH}_${LIBNULLPAY_VERSION}.zip
-    unzip libnullpay_android_${ARCH}_1.5.0.zip
+    unzip libnullpay_android_${ARCH}_${LIBNULLPAY_VERSION}.zip
 
 }
 

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -14,6 +14,7 @@ setup() {
     fi
     cd runtime_android_build
 	retrieve_prebuilt_binaries
+	clone_indy_sdk
 	generate_flags $1
     if [ ! -d "toolchains" ]; then
         mkdir toolchains
@@ -101,11 +102,22 @@ generate_flags(){
     fi
 }
 
+clone_indy_sdk() {
+    if [ ! -d "indy-sdk" ]; then
+        echo "cloning indy-sdk"
+        #git clone https://github.com/evernym/indy-sdk.git
+        git clone https://github.com/hyperledger/indy-sdk.git
+    fi
+}
 
 get_libindy() {
     set -xv
-    wget https://transfer.sh/73l3U/libindy_android_${ARCH}.zip
-    unzip libindy_android_${ARCH}.zip
+    wget https://transfer.sh/73l3U/libindy_android_x86.zip
+    unzip libindy_android_x86.zip
+    wget https://transfer.sh/cssbl/libindy_android_arm64.zip
+    unzip libindy_android_arm64.zip
+    wget https://transfer.sh/TbH7L/libindy_android_arm.zip
+    unzip libindy_android_arm.zip
 
 }
 

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -14,7 +14,6 @@ setup() {
     fi
     cd runtime_android_build
 	retrieve_prebuilt_binaries
-	clone_indy_sdk
 	generate_flags $1
     if [ ! -d "toolchains" ]; then
         mkdir toolchains
@@ -102,25 +101,16 @@ generate_flags(){
     fi
 }
 
-clone_indy_sdk() {
-    if [ ! -d "indy-sdk" ]; then
-        echo "cloning indy-sdk"
-        #git clone https://github.com/evernym/indy-sdk.git
-        git clone https://github.com/hyperledger/indy-sdk.git
-    fi
-}
 
-build_libindy() {
+get_libindy() {
     set -xv
+    wget https://transfer.sh/73l3U/libindy_android_x86.zip
+    unzip libindy_android_x86.zip
+    wget https://transfer.sh/cssbl/libindy_android_arm64.zip
+    unzip libindy_android_arm64.zip
+    wget https://transfer.sh/TbH7L/libindy_android_arm.zip
+    unzip libindy_android_arm.zip
 
-    LIBINDY_PATH=indy-sdk/libindy/build_scripts/android
-    PREBUILT_BIN=../../../..
-    pushd ${LIBINDY_PATH}
-    mkdir -p toolchains/
-    ./build.withoutdocker.sh ${ARCH} ${PLATFORM} ${TRIPLET} ${PREBUILT_BIN}/openssl_${ARCH} ${PREBUILT_BIN}/libsodium_${ARCH} ${PREBUILT_BIN}/libzmq_${ARCH}
-    popd
-    mv ${LIBINDY_PATH}/libindy_${ARCH} .
-    mv ${LIBINDY_PATH}/toolchains indy-sdk/libnullpay/build_scripts/android
 }
 
 build_libnullpay() {
@@ -171,6 +161,6 @@ build_vcx() {
 }
 
 setup $1
-build_libindy $1
+get_libindy $1
 build_libnullpay $1
 build_vcx $1

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -117,7 +117,7 @@ get_libindy() {
     [ -z ${LIBINDY_VERSION} ] && exit 1
 
     wget https://repo.sovrin.org/android/libindy/${LIBINDY_BRANCH}/${LIBINDY_VERSION}/libindy_android_${ARCH}_${LIBINDY_VERSION}.zip
-    unzip libindy_android_${ARCH}_${LIBINDY_VERSION}.zip
+    unzip libindy_android_${ARCH}.${LIBINDY_VERSION}.zip
 
 }
 
@@ -126,7 +126,7 @@ get_libnullpay() {
     [ -z ${LIBNULLPAY_BRANCH} ] && exit 1
     [ -z ${LIBNULLPAY_VERSION} ] && exit 1
     wget https://repo.sovrin.org/android/libnullpay/${LIBNULLPAY_BRANCH}/${LIBNULLPAY_VERSION}/libnullpay_android_${ARCH}_${LIBNULLPAY_VERSION}.zip
-    unzip libnullpay_android_${ARCH}_${LIBNULLPAY_VERSION}.zip
+    unzip libnullpay_android_${ARCH}.${LIBNULLPAY_VERSION}.zip
 
 }
 

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -111,24 +111,23 @@ clone_indy_sdk() {
 }
 
 get_libindy() {
+
     set -xv
-    wget https://transfer.sh/73l3U/libindy_android_x86.zip
-    wget https://transfer.sh/TbH7L/libindy_android_arm.zip
-    wget https://transfer.sh/cssbl/libindy_android_arm64.zip
-    unzip libindy_android_x86.zip
-    unzip libindy_android_arm.zip
-    unzip libindy_android_arm64.zip
+    [ -z ${LIBINDY_BRANCH} ] && exit 1
+    [ -z ${LIBINDY_VERSION} ] && exit 1
+
+    wget https://repo.sovrin.org/android/libindy/${LIBINDY_BRANCH}/${LIBINDY_VERSION}/libindy_android_${ARCH}_${LIBINDY_VERSION}.zip
+    unzip libindy_android_${ARCH}_1.5.0.zip
 
 }
 
 get_libnullpay() {
     set -xv
-    wget https://transfer.sh/QujdH/libnullpay_android_x86.zip
-    wget https://transfer.sh/YFSnM/libnullpay_android_arm.zip
-    wget https://transfer.sh/UxDBL/libnullpay_android_arm64.zip
-    unzip libnullpay_android_x86.zip
-    unzip libnullpay_android_arm.zip
-    unzip libnullpay_android_arm64.zip
+    [ -z ${LIBNULLPAY_BRANCH} ] && exit 1
+    [ -z ${LIBNULLPAY_VERSION} ] && exit 1
+    wget https://repo.sovrin.org/android/libnullpay/${LIBNULLPAY_BRANCH}/${LIBNULLPAY_VERSION}/libnullpay_android_${ARCH}_${LIBNULLPAY_VERSION}.zip
+    unzip libnullpay_android_${ARCH}_1.5.0.zip
+
 }
 
 build_vcx() {

--- a/vcx/ci/scripts/androidBuild.sh
+++ b/vcx/ci/scripts/androidBuild.sh
@@ -113,33 +113,22 @@ clone_indy_sdk() {
 get_libindy() {
     set -xv
     wget https://transfer.sh/73l3U/libindy_android_x86.zip
-    unzip libindy_android_x86.zip
-    wget https://transfer.sh/cssbl/libindy_android_arm64.zip
-    unzip libindy_android_arm64.zip
     wget https://transfer.sh/TbH7L/libindy_android_arm.zip
+    wget https://transfer.sh/cssbl/libindy_android_arm64.zip
+    unzip libindy_android_x86.zip
     unzip libindy_android_arm.zip
+    unzip libindy_android_arm64.zip
 
 }
 
-build_libnullpay() {
-    LIBNULLPAY_PATH=indy-sdk/libnullpay/build_scripts/android
-    LIBINDY_BIN="$(realpath libindy_${ARCH})"
-    if [ ! -d libindy_${ARCH} ]; then
-        echo "missing libindy_${ARCH}. Cannot proceed without it."
-        exit 1
-    fi
-
-    pushd ${LIBNULLPAY_PATH}
-    if [ ! -d toolchains ]; then
-        mkdir toolchains/linux
-    fi
-    ./build.withoutdocker.sh ${ARCH} ${PLATFORM} ${TRIPLET} ${LIBINDY_BIN}
-    popd
-
-    mv ${LIBNULLPAY_PATH}/libnullpay_${ARCH} .
-
-    # This is to prevent side effect in other builds
-    rm -rf ${LIBNULLPAY_PATH}/toolchains/linux
+get_libnullpay() {
+    set -xv
+    wget https://transfer.sh/QujdH/libnullpay_android_x86.zip
+    wget https://transfer.sh/YFSnM/libnullpay_android_arm.zip
+    wget https://transfer.sh/UxDBL/libnullpay_android_arm64.zip
+    unzip libnullpay_android_x86.zip
+    unzip libnullpay_android_arm.zip
+    unzip libnullpay_android_arm64.zip
 }
 
 build_vcx() {
@@ -170,5 +159,5 @@ build_vcx() {
 
 setup $1
 get_libindy $1
-build_libnullpay $1
+get_libnullpay $1
 build_vcx $1

--- a/vcx/libvcx/build_scripts/android/vcx/build.nondocker.sh
+++ b/vcx/libvcx/build_scripts/android/vcx/build.nondocker.sh
@@ -77,6 +77,10 @@ if [ -z "${LIBINDY_DIR}" ] ; then
     else
         LIBINDY_DIR=$7
     fi
+
+    if [ -d "${LIBINDY_DIR}/lib" ] ; then
+            LIBINDY_DIR="${LIBINDY_DIR}/lib"
+    fi
 fi
 
 if [ -z "${LIBNULLPAY_DIR}" ] ; then
@@ -89,6 +93,9 @@ if [ -z "${LIBNULLPAY_DIR}" ] ; then
         exit 1
     else
         LIBNULLPAY_DIR=$8
+    fi
+    if [ -d "${LIBNULLPAY_DIR}/lib" ] ; then
+            LIBNULLPAY_DIR="${LIBNULLPAY_DIR}/lib"
     fi
 fi
 


### PR DESCRIPTION
The CI pipeline now does not build libindy and libnullpay from scratch. The prebuilt binaries are downloaded from the repo.sovrin.org/android

This commit downloads prebuilt of libindy and libnullpay which was built with the commit hash `db5a92655ea4edd06795d9ed19284aece3815a21` . This hash is the same from which the deb package https://repo.sovrin.org/sdk/lib/apt/xenial/master/libindy_1.5.0~619_amd64.deb was built.

In future when libvcx starts to use the stable of libindy, minor modifications to the download path might be needed.