### PR TITLE
Libindy 1.6.1 cocoapod, Latest libvcx, Fix ErrorCode enum

### DIFF
--- a/Specs/vcx/0.0.24/vcx.podspec
+++ b/Specs/vcx/0.0.24/vcx.podspec
@@ -1,0 +1,44 @@
+#
+# Be sure to run `pod lib lint vcx.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'vcx'
+  s.version          = '0.0.24'
+  s.summary          = 'The Objective-C wrapper around the libvcx shared library.'
+
+# This description is used to generate tags and improve search results.
+#   * Think: What does it do? Why did you write it? What is the focus?
+#   * Try to keep it short, snappy and to the point.
+#   * Write the description between the DESC delimiters below.
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+
+  s.description      = <<-DESC
+The ConnectMe mobile app on the iOS platform will call into the libvcx shared library
+from Objective-C. This pod is a very thin Objective-C wrapper that allows react native to call
+through to the libvcx shared library.
+                       DESC
+
+  s.homepage         = 'https://www.evernym.com/'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'evernym-ios-dev' => 'iosdev@evernym.com' }
+  s.source           = { :http => 'https://repo.corp.evernym.com/filely/ios/vcx.framework_20180729.1548_universal.zip' }
+
+  s.ios.deployment_target = '8.0'
+
+  #s.source_files = '**/vcx/Classes/**/*','**/Example/Classes/**/*'
+  
+  # s.resource_bundles = {
+  #   'vcx' => ['**/vcx/Assets/*.png']
+  # }
+  s.ios.vendored_frameworks="vcx/vcx.framework"
+  s.compiler_flags = '-ObjC'
+  s.public_header_files = 'vcx/vcx.framework/include/*.h'
+  s.ios.vendored_library = 'vcx/vcx.framework/lib/libvcx.a'
+  # s.frameworks = 'UIKit', 'MapKit'
+  # s.dependency 'AFNetworking', '~> 2.3'
+end

--- a/vcx/libvcx/build_scripts/android/mac/mac.03.libindy.build.sh
+++ b/vcx/libvcx/build_scripts/android/mac/mac.03.libindy.build.sh
@@ -109,7 +109,7 @@ export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_armv7/lib; echo "ANDR
 #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_armv7/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
 export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/armeabi-v7a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
 sed -i .bak 's/\"\"\.as_ptr() as \*const i8/\"\"\.as_ptr() as \*const u8/' src/services/wallet/storage/plugged/mod.rs
-cargo build --target armv7-linux-androideabi --release --verbose
+cargo build --target armv7-linux-androideabi --release
 echo "-----------------------------------------------------------------------------------------------"
 
 # export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
@@ -133,7 +133,7 @@ export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86/lib; echo "ANDROI
 #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_x86/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
 export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/sqlite3-android/obj/local/x86; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
 sed -i .bak 's/\"\"\.as_ptr() as \*const u8/\"\"\.as_ptr() as \*const i8/' src/services/wallet/storage/plugged/mod.rs
-cargo build --target i686-linux-android --release --verbose
+cargo build --target i686-linux-android --release
 echo "-----------------------------------------------------------------------------------------------"
 
 # export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
@@ -194,7 +194,7 @@ export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_armv7/lib; echo "ANDR
 #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_armv7/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
 export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/armeabi-v7a; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
 export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/armv7-linux-androideabi/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
-cargo build --target armv7-linux-androideabi --release --verbose
+cargo build --target armv7-linux-androideabi --release
 echo "-----------------------------------------------------------------------------------------------"
 
 # export PATH=$WORK_DIR/NDK/arm64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"
@@ -218,7 +218,7 @@ export ANDROID_ZMQ_LIB=$WORK_DIR/libzmq-android/zmq/libzmq_x86/lib; echo "ANDROI
 #export LIBZMQ_INCLUDE_DIR=$WORK_DIR/libzmq-android/zmq/libzmq_x86/include; echo "LIBZMQ_INCLUDE_DIR: $LIBZMQ_INCLUDE_DIR"
 export ANDROID_SQLITE_LIB=$WORK_DIR/libsqlite3-android/x86; echo "ANDROID_SQLITE_LIB: $ANDROID_SQLITE_LIB"
 export LIBINDY_DIR=$WORK_DIR/vcx-indy-sdk/libindy/target/i686-linux-android/release; echo "LIBINDY_DIR: $LIBINDY_DIR"
-cargo build --target i686-linux-android --release --verbose
+cargo build --target i686-linux-android --release
 echo "-----------------------------------------------------------------------------------------------"
 
 # export PATH=$WORK_DIR/NDK/x86_64/bin:$ORIGINAL_PATH; echo "PATH: $PATH"

--- a/vcx/libvcx/build_scripts/android/mac/mac.upload.android.release.build.sh
+++ b/vcx/libvcx/build_scripts/android/mac/mac.upload.android.release.build.sh
@@ -11,12 +11,22 @@ VCX_SDK=$(abspath "$VCX_SDK")
 
 cd $VCX_SDK/vcx/wrappers/java/vcx/
 
-./gradlew clean assembleDebug
+./gradlew clean assembleRelease
 
 cd $VCX_SDK/vcx/wrappers/java/vcx/build/outputs/aar/
-AAR_FILE=$(ls *-debug.aar)
+AAR_FILE=$(ls *-release.aar)
 AAR_VER=$(echo ${AAR_FILE} | cut -c 17-38)
 # install generated .aar file
 mvn install:install-file -Dfile=${AAR_FILE} -DgroupId=com.connectme \
 -DartifactId=vcx -Dversion=${AAR_VER} -Dpackaging=aar
 echo $AAR_VER | pbcopy
+
+# Upload to public cloud repo
+mvn -e deploy:deploy-file \
+   -Durl="https://evernym.mycloudrepo.io/repositories/libvcx-android" \
+   -DrepositoryId="io.cloudrepo" \
+   -Dversion="${AAR_VER}" \
+   -Dfile=${AAR_FILE} \
+   -DartifactId="vcx" \
+   -Dpackaging="aar" \
+   -DgroupId="com.evernym"

--- a/vcx/libvcx/build_scripts/ios/mac/mac.03.libindy.build.sh
+++ b/vcx/libvcx/build_scripts/ios/mac/mac.03.libindy.build.sh
@@ -71,8 +71,8 @@ fi
 #cargo build
 # To build for iOS
 #echo "cargo lipo --release --verbose --targets=${IOS_TARGETS}"
-cargo lipo --release --verbose --targets="${IOS_TARGETS}"
-# cargo lipo --release --targets="${IOS_TARGETS}"
+# cargo lipo --release --verbose --targets="${IOS_TARGETS}"
+cargo lipo --release --targets="${IOS_TARGETS}"
 #cargo lipo
 
 #########################################################################################################################
@@ -99,6 +99,6 @@ fi
 #cargo build
 # To build for iOS
 #echo "cargo lipo --release --verbose --targets=${IOS_TARGETS}"
-cargo lipo --release --verbose --targets="${IOS_TARGETS}"
-# cargo lipo --release --targets="${IOS_TARGETS}"
+# cargo lipo --release --verbose --targets="${IOS_TARGETS}"
+cargo lipo --release --targets="${IOS_TARGETS}"
 #cargo lipo

--- a/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/VcxException.java
+++ b/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/VcxException.java
@@ -1,6 +1,8 @@
 package com.evernym.sdk.vcx;
 
 
+import android.util.Log;
+
 import com.evernym.sdk.vcx.connection.ConnectionErrorException;
 import com.evernym.sdk.vcx.connection.InvalidConnectionHandleException;
 import com.evernym.sdk.vcx.connection.InvalidInviteDetailsException;
@@ -65,6 +67,7 @@ import com.evernym.sdk.vcx.vcx.WalletItemAlreadyExistsException;
  */
 public class VcxException extends Exception {
 
+    private static String TAG = "JAVA_WRAPPER::VCX_API ";
     private static final long serialVersionUID = 2650355290834266234L;
     private int sdkErrorCode;
 
@@ -93,8 +96,13 @@ public class VcxException extends Exception {
      * @param sdkErrorCode The SDK error code to construct the exception from.
      */
     static VcxException fromSdkError(int sdkErrorCode) {
-
-        ErrorCode errorCode = ErrorCode.valueOf(sdkErrorCode);
+        ErrorCode errorCode = ErrorCode.UNKNOWN_ERROR;
+        try {
+            errorCode = ErrorCode.valueOf(sdkErrorCode);
+            if (errorCode == null) {
+                errorCode = ErrorCode.UNKNOWN_ERROR;
+            }
+        } catch(Exception e) {}
 
         switch (errorCode) {
             case UNKNOWN_ERROR:

--- a/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/VcxJava.java
+++ b/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/VcxJava.java
@@ -85,12 +85,23 @@ public class VcxJava {
 		 * 
 		 * @param future The future.
 		 * @param err The error value to check.
-		 * @return true if the error code indeicated SUCCESS, otherwise false.
+		 * @return true if the error code indicate SUCCESS, otherwise false.
 		 */
 		protected static boolean checkCallback(CompletableFuture<?> future, int err) {
+			ErrorCode errorCode = ErrorCode.UNKNOWN_ERROR;
 
-			ErrorCode errorCode = ErrorCode.valueOf(err);
-			if (! ErrorCode.SUCCESS.equals(errorCode)) { future.completeExceptionally(VcxException.fromSdkError(err)); return false; }
+			try {
+				errorCode = ErrorCode.valueOf(err);
+				if (errorCode == null) {
+					errorCode = ErrorCode.UNKNOWN_ERROR;
+				}
+			} catch(Exception e) {}
+
+			if (! ErrorCode.SUCCESS.equals(errorCode)) {
+				future.completeExceptionally(VcxException.fromSdkError(err));
+
+				return false;
+			}
 
 			return true;
 		}

--- a/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
+++ b/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
@@ -81,28 +81,4 @@ public class VcxApi extends VcxJava.API {
 
     }
 
-//    public static CompletableFuture<Integer> vcxGenerateProof(
-//            String proofRequestId,
-//            String requestedAttrs,
-//            String requestedPredicates,
-//            String proofName
-//    ) throws VcxException {
-//        ParamGuard.notNull(proofRequestId, "proofRequestId");
-//        ParamGuard.notNullOrWhiteSpace(requestedAttrs, "requestedAttrs");
-//        ParamGuard.notNullOrWhiteSpace(requestedPredicates, "requestedPredicates");
-//        ParamGuard.notNullOrWhiteSpace(proofName, "proofName");
-//        CompletableFuture<Integer> future = new CompletableFuture<Integer>();
-//        int commandHandle = addFuture(future);
-//
-//        int result = LibVcx.api.vcx_proof_create(
-//                proofRequestId,
-//                requestedAttrs,
-//                requestedPredicates,
-//                proofName,
-//                vcxGenerateProofCB
-//        );
-//        checkResult(result);
-//        return future;
-//    }
-
 }

--- a/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/wallet/WalletApi.java
+++ b/vcx/wrappers/java/vcx/src/main/java/com/evernym/sdk/vcx/wallet/WalletApi.java
@@ -1,5 +1,7 @@
 package com.evernym.sdk.vcx.wallet;
 
+import android.util.Log;
+
 import com.evernym.sdk.vcx.LibVcx;
 import com.evernym.sdk.vcx.ParamGuard;
 import com.evernym.sdk.vcx.VcxException;
@@ -9,6 +11,7 @@ import com.sun.jna.Callback;
 import java9.util.concurrent.CompletableFuture;
 
 public class WalletApi extends VcxJava.API {
+    private static String TAG = "JAVA_WRAPPER::API_VCX::WALLET";
 
     private WalletApi(){}
 


### PR DESCRIPTION
- Latest cocoapod release 0.0.24 with libIndy 1.6.1 and latest libvcx
- Fix ErrorCode enum issue in Java wrapper so that Java wrapper does not crash if unknown error code integer is passed from underlying libIndy or libvcx layer
- Removed verbose logging from builds